### PR TITLE
Localize browser setup status copy

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,135 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+
+type Locale = "es" | "fr" | "pt-BR";
+type Params = Record<string, string | number>;
+
+const namespace = "pi-browser-harness";
+
+const fallback = {
+  "status.notStarted": "Browser daemon not started. Run /browser-setup first.",
+  "status.browser": "Browser: {state}",
+  "status.connected": "🟢 Connected",
+  "status.disconnected": "🔴 Disconnected",
+  "status.session": "Session: {sessionId}",
+  "status.browserId": "Browser ID: {browserId}",
+  "status.dialogOpen": "⚠️  Dialog open: {type} — \"{message}\"",
+  "reload.notStarted": "Browser daemon not started.",
+  "reload.start": "Restarting browser daemon...",
+  "reload.done": "Browser daemon restarted ✓",
+  "reload.failed": "Restart failed: {message}",
+  "ui.connected": "🟢 Browser connected",
+  "ui.setupNeeded": "🔴 Browser — run /browser-setup",
+  "setup.command": "Connect pi to your Chrome browser",
+  "setup.checking": "browser setup: checking Chrome...",
+  "setup.notDetected": "Chrome/Chromium/Edge not detected. Please start your browser and retry /browser-setup.",
+  "setup.running": "Chrome is running ✓",
+  "setup.connecting": "Connecting to Chrome DevTools...",
+  "setup.connected": "Connected to Chrome ✓",
+  "setup.remoteDebugging": "Chrome remote debugging needs to be enabled.\n\nOpen chrome://inspect/#remote-debugging in your browser, tick the\n\"Discover network targets\" / Allow checkbox, then run /browser-setup again.\n\nOr set BU_CDP_WS to a remote browser WebSocket URL.",
+  "setup.connectionFailed": "Connection failed: {message}",
+  "setup.testing": "Testing browser control...",
+  "setup.verified": "Browser control verified ✓\nNavigated to: {url}",
+  "setup.testNavigationFailed": "Browser connected but test navigation failed: {message}",
+} as const;
+
+type Key = keyof typeof fallback;
+
+const translations: Record<Locale, Partial<Record<Key, string>>> = {
+  es: {
+    "status.notStarted": "El daemon del navegador no se inició. Ejecuta /browser-setup primero.",
+    "status.browser": "Navegador: {state}",
+    "status.connected": "🟢 Conectado",
+    "status.disconnected": "🔴 Desconectado",
+    "status.session": "Sesión: {sessionId}",
+    "status.browserId": "ID del navegador: {browserId}",
+    "status.dialogOpen": "⚠️  Diálogo abierto: {type} — \"{message}\"",
+    "reload.notStarted": "El daemon del navegador no se inició.",
+    "reload.start": "Reiniciando daemon del navegador...",
+    "reload.done": "Daemon del navegador reiniciado ✓",
+    "reload.failed": "Error al reiniciar: {message}",
+    "ui.connected": "🟢 Navegador conectado",
+    "ui.setupNeeded": "🔴 Navegador — ejecuta /browser-setup",
+    "setup.command": "Conectar pi a tu navegador Chrome",
+    "setup.checking": "configuración del navegador: comprobando Chrome...",
+    "setup.notDetected": "No se detectó Chrome/Chromium/Edge. Inicia el navegador y vuelve a ejecutar /browser-setup.",
+    "setup.running": "Chrome está en ejecución ✓",
+    "setup.connecting": "Conectando a Chrome DevTools...",
+    "setup.connected": "Conectado a Chrome ✓",
+    "setup.remoteDebugging": "La depuración remota de Chrome debe estar habilitada.\n\nAbre chrome://inspect/#remote-debugging en el navegador, marca\n\"Discover network targets\" / la casilla Allow y vuelve a ejecutar /browser-setup.\n\nO define BU_CDP_WS con una URL WebSocket de navegador remoto.",
+    "setup.connectionFailed": "Conexión fallida: {message}",
+    "setup.testing": "Probando control del navegador...",
+    "setup.verified": "Control del navegador verificado ✓\nNavegado a: {url}",
+    "setup.testNavigationFailed": "El navegador se conectó, pero la navegación de prueba falló: {message}",
+  },
+  fr: {
+    "status.notStarted": "Le daemon du navigateur n’est pas démarré. Exécutez /browser-setup d’abord.",
+    "status.browser": "Navigateur : {state}",
+    "status.connected": "🟢 Connecté",
+    "status.disconnected": "🔴 Déconnecté",
+    "status.session": "Session : {sessionId}",
+    "status.browserId": "ID du navigateur : {browserId}",
+    "status.dialogOpen": "⚠️  Boîte de dialogue ouverte : {type} — \"{message}\"",
+    "reload.notStarted": "Le daemon du navigateur n’est pas démarré.",
+    "reload.start": "Redémarrage du daemon du navigateur...",
+    "reload.done": "Daemon du navigateur redémarré ✓",
+    "reload.failed": "Échec du redémarrage : {message}",
+    "ui.connected": "🟢 Navigateur connecté",
+    "ui.setupNeeded": "🔴 Navigateur — exécutez /browser-setup",
+    "setup.command": "Connecter pi à votre navigateur Chrome",
+    "setup.checking": "configuration du navigateur : vérification de Chrome...",
+    "setup.notDetected": "Chrome/Chromium/Edge non détecté. Démarrez votre navigateur puis relancez /browser-setup.",
+    "setup.running": "Chrome est en cours d’exécution ✓",
+    "setup.connecting": "Connexion à Chrome DevTools...",
+    "setup.connected": "Connecté à Chrome ✓",
+    "setup.remoteDebugging": "Le débogage distant de Chrome doit être activé.\n\nOuvrez chrome://inspect/#remote-debugging dans votre navigateur, cochez\n\"Discover network targets\" / Allow, puis relancez /browser-setup.\n\nOu définissez BU_CDP_WS avec une URL WebSocket de navigateur distant.",
+    "setup.connectionFailed": "Connexion échouée : {message}",
+    "setup.testing": "Test du contrôle du navigateur...",
+    "setup.verified": "Contrôle du navigateur vérifié ✓\nNavigation vers : {url}",
+    "setup.testNavigationFailed": "Le navigateur est connecté, mais la navigation de test a échoué : {message}",
+  },
+  "pt-BR": {
+    "status.notStarted": "O daemon do navegador não foi iniciado. Execute /browser-setup primeiro.",
+    "status.browser": "Navegador: {state}",
+    "status.connected": "🟢 Conectado",
+    "status.disconnected": "🔴 Desconectado",
+    "status.session": "Sessão: {sessionId}",
+    "status.browserId": "ID do navegador: {browserId}",
+    "status.dialogOpen": "⚠️  Diálogo aberto: {type} — \"{message}\"",
+    "reload.notStarted": "O daemon do navegador não foi iniciado.",
+    "reload.start": "Reiniciando daemon do navegador...",
+    "reload.done": "Daemon do navegador reiniciado ✓",
+    "reload.failed": "Falha ao reiniciar: {message}",
+    "ui.connected": "🟢 Navegador conectado",
+    "ui.setupNeeded": "🔴 Navegador — execute /browser-setup",
+    "setup.command": "Conectar o pi ao seu navegador Chrome",
+    "setup.checking": "configuração do navegador: verificando Chrome...",
+    "setup.notDetected": "Chrome/Chromium/Edge não detectado. Inicie o navegador e tente /browser-setup novamente.",
+    "setup.running": "Chrome está em execução ✓",
+    "setup.connecting": "Conectando ao Chrome DevTools...",
+    "setup.connected": "Conectado ao Chrome ✓",
+    "setup.remoteDebugging": "A depuração remota do Chrome precisa estar ativada.\n\nAbra chrome://inspect/#remote-debugging no navegador, marque\n\"Discover network targets\" / Allow e execute /browser-setup novamente.\n\nOu defina BU_CDP_WS com uma URL WebSocket de navegador remoto.",
+    "setup.connectionFailed": "Falha na conexão: {message}",
+    "setup.testing": "Testando controle do navegador...",
+    "setup.verified": "Controle do navegador verificado ✓\nNavegou para: {url}",
+    "setup.testNavigationFailed": "O navegador conectou, mas a navegação de teste falhou: {message}",
+  },
+};
+
+let currentLocale: string | undefined;
+
+function format(template: string, params: Params = {}): string {
+  return template.replace(/\{(\w+)\}/g, (_match, key) => String(params[key] ?? `{${key}}`));
+}
+
+export function t(key: Key, params?: Params): string {
+  const locale = currentLocale as Locale | undefined;
+  return format((locale ? translations[locale]?.[key] : undefined) ?? fallback[key], params);
+}
+
+export function initI18n(pi: ExtensionAPI): void {
+  pi.events?.emit?.("pi-core/i18n/registerBundle", { namespace, defaultLocale: "en", fallback, translations });
+  pi.events?.on?.("pi-core/i18n/localeChanged", (event: unknown) => {
+    currentLocale = event && typeof event === "object" && "locale" in event ? String((event as { locale?: unknown }).locale ?? "") : undefined;
+  });
+  pi.events?.emit?.("pi-core/i18n/requestApi", { namespace, onApi(api: { getLocale?: () => string | undefined }) { currentLocale = api.getLocale?.(); } });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import { registerRenderers } from "./renderers";
 import { registerSetupCommand } from "./setup";
 import { type BrowserState, defaultState, persistState, restoreState } from "./state";
 import { cleanupTempDirs, registerTools } from "./tools";
+import { initI18n, t } from "./i18n";
 
 export default function browserHarnessExtension(pi: ExtensionAPI) {
   // ── Resolve namespace ──────────────────────────────────────────────────────
@@ -59,18 +60,18 @@ export default function browserHarnessExtension(pi: ExtensionAPI) {
     description: "Show browser connection status and current page",
     handler: async (_args, ctx) => {
       if (!daemon) {
-        ctx.ui.notify("Browser daemon not started. Run /browser-setup first.", "warning");
+        ctx.ui.notify(t("status.notStarted"), "warning");
         return;
       }
 
       const status = daemon.getStatus();
       const lines = [
-        `Browser: ${status.alive ? "🟢 Connected" : "🔴 Disconnected"}`,
-        `Session: ${status.sessionId || "none"}`,
+        t("status.browser", { state: status.alive ? t("status.connected") : t("status.disconnected") }),
+        t("status.session", { sessionId: status.sessionId || "none" }),
       ];
 
       if (status.remoteBrowserId) {
-        lines.push(`Browser ID: ${status.remoteBrowserId}`);
+        lines.push(t("status.browserId", { browserId: status.remoteBrowserId }));
       }
 
       // Try to get current page info
@@ -78,7 +79,7 @@ export default function browserHarnessExtension(pi: ExtensionAPI) {
         try {
           const info = await daemon.getPageInfo();
           if ("dialog" in info) {
-            lines.push(`\n⚠️  Dialog open: ${info.dialog.type} — "${info.dialog.message}"`);
+            lines.push(`\n${t("status.dialogOpen", { type: info.dialog.type, message: info.dialog.message })}`);
           } else {
             lines.push(`\nCurrent Page:`);
             lines.push(`  URL: ${info.url}`);
@@ -98,18 +99,18 @@ export default function browserHarnessExtension(pi: ExtensionAPI) {
     description: "Restart the browser daemon",
     handler: async (_args, ctx) => {
       if (!daemon) {
-        ctx.ui.notify("Browser daemon not started.", "warning");
+        ctx.ui.notify(t("reload.notStarted"), "warning");
         return;
       }
 
-      ctx.ui.notify("Restarting browser daemon...", "info");
+      ctx.ui.notify(t("reload.start"), "info");
       try {
         await daemon.stop();
         await daemon.start();
-        ctx.ui.notify("Browser daemon restarted ✓", "info");
+        ctx.ui.notify(t("reload.done"), "info");
       } catch (err) {
         ctx.ui.notify(
-          `Restart failed: ${err instanceof Error ? err.message : String(err)}`,
+          t("reload.failed", { message: err instanceof Error ? err.message : String(err) }),
           "error",
         );
       }
@@ -149,9 +150,9 @@ export default function browserHarnessExtension(pi: ExtensionAPI) {
 
     // Update status
     if (daemon.getStatus().alive) {
-      ctx.ui.setStatus("browser", "🟢 Browser connected");
+      ctx.ui.setStatus("browser", t("ui.connected"));
     } else {
-      ctx.ui.setStatus("browser", "🔴 Browser — run /browser-setup");
+      ctx.ui.setStatus("browser", t("ui.setupNeeded"));
     }
   });
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -6,10 +6,11 @@
 import type { ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
 import { execSync } from "node:child_process";
 import type { BrowserDaemon } from "./daemon";
+import { t } from "./i18n";
 
 export function registerSetupCommand(pi: ExtensionAPI, daemon: BrowserDaemon): void {
   pi.registerCommand("browser-setup", {
-    description: "Connect pi to your Chrome browser",
+    description: t("setup.command"),
     handler: async (_args, ctx) => {
       await runSetup(ctx, daemon);
     },
@@ -17,24 +18,24 @@ export function registerSetupCommand(pi: ExtensionAPI, daemon: BrowserDaemon): v
 }
 
 async function runSetup(ctx: ExtensionContext, daemon: BrowserDaemon): Promise<void> {
-  ctx.ui.notify("browser setup: checking Chrome...", "info");
+  ctx.ui.notify(t("setup.checking"), "info");
 
   // Step 1: Check Chrome is running
   const chromeRunning = checkChromeRunning();
   if (!chromeRunning) {
     ctx.ui.notify(
-      "Chrome/Chromium/Edge not detected. Please start your browser and retry /browser-setup.",
+      t("setup.notDetected"),
       "error",
     );
     return;
   }
-  ctx.ui.notify("Chrome is running ✓", "info");
+  ctx.ui.notify(t("setup.running"), "info");
 
   // Step 2: Try to connect to Chrome DevTools
-  ctx.ui.notify("Connecting to Chrome DevTools...", "info");
+  ctx.ui.notify(t("setup.connecting"), "info");
   try {
     await daemon.start();
-    ctx.ui.notify("Connected to Chrome ✓", "info");
+    ctx.ui.notify(t("setup.connected"), "info");
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const lower = msg.toLowerCase();
@@ -45,35 +46,26 @@ async function runSetup(ctx: ExtensionContext, daemon: BrowserDaemon): Promise<v
       lower.includes("econnrefused") ||
       lower.includes("cannot reach chrome devtools")
     ) {
-      ctx.ui.notify(
-        "Chrome remote debugging needs to be enabled.\n\n" +
-          "Open chrome://inspect/#remote-debugging in your browser, tick the\n" +
-          "\"Discover network targets\" / Allow checkbox, then run /browser-setup again.\n\n" +
-          "Or set BU_CDP_WS to a remote browser WebSocket URL.",
-        "warning",
-      );
+      ctx.ui.notify(t("setup.remoteDebugging"), "warning");
       return;
     }
 
-    ctx.ui.notify(`Connection failed: ${msg}`, "error");
+    ctx.ui.notify(t("setup.connectionFailed", { message: msg }), "error");
     return;
   }
 
   // Step 3: Verify with test navigation
-  ctx.ui.notify("Testing browser control...", "info");
+  ctx.ui.notify(t("setup.testing"), "info");
   try {
     await daemon.newTab("https://github.com");
     const info = await daemon.getPageInfo();
     if ("dialog" in info) {
       await daemon.cdp("Page.handleJavaScriptDialog", { accept: true });
     }
-    ctx.ui.notify(
-      `Browser control verified ✓\nNavigated to: ${"url" in info ? info.url : "github.com"}`,
-      "info",
-    );
+    ctx.ui.notify(t("setup.verified", { url: "url" in info ? info.url : "github.com" }), "info");
   } catch (err) {
     ctx.ui.notify(
-      `Browser connected but test navigation failed: ${err instanceof Error ? err.message : String(err)}`,
+      t("setup.testNavigationFailed", { message: err instanceof Error ? err.message : String(err) }),
       "warning",
     );
   }


### PR DESCRIPTION
This keeps pi-browser-harness English by default, but makes the browser setup/status path optionally localizable.

Why this slice:
- `/browser-setup`, `/browser-status`, and `/browser-reload-daemon` are the points where users decide whether Chrome is running, remote debugging is enabled, the daemon is connected, or a dialog is blocking control.
- I kept this to setup/status/reload copy only; no README, skill, or broad tool-output localization.

What changed:
- adds a small optional i18n bridge with English fallbacks
- adds es/fr/pt-BR bundles for browser setup, connection status, reload status, and dialog warnings
- registers the bundle without adding a dependency
- preserves current behavior when no i18n provider is present

Validation:
- `npm run typecheck` passed
- `npm pack --dry-run` passed
- local npm install warned that this checkout expects Node >=22; my local runtime is Node 20.19.0, but typecheck still passed

The changes are isolated to `src/i18n.ts`, `src/index.ts`, and `src/setup.ts`, so they should be easy to revert if you do not want localization in this path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localization support enabling dynamic message translation based on user locale

* **Improvements**
  * Browser status, setup guidance, and session notifications now display localized messages instead of hardcoded strings

<!-- end of auto-generated comment: release notes by coderabbit.ai -->