### PR TITLE
fix: prevent TUI crash when screenshot path overflows terminal width

### DIFF
--- a/src/domains/screenshot.ts
+++ b/src/domains/screenshot.ts
@@ -1,7 +1,7 @@
 import { readFileSync } from "node:fs";
 import { writeFile, rename } from "node:fs/promises";
 import { Type } from "typebox";
-import { Image, type ImageTheme, Text } from "@mariozechner/pi-tui";
+import { Image, type ImageTheme, Text, truncateToWidth, visibleWidth } from "@mariozechner/pi-tui";
 import type { BrowserClient } from "../client";
 import { type Result, err, ok } from "../util/result";
 import { defineBrowserTool, type ToolErr, type ToolOk } from "../util/tool";
@@ -98,11 +98,22 @@ export const screenshotTool = defineBrowserTool({
       const imageTheme: ImageTheme = {
         fallbackColor: (str: string) => theme.fg("dim", str),
       };
-      return new Image(b64, mimeType, imageTheme, {
+      const image = new Image(b64, mimeType, imageTheme, {
         maxWidthCells: 80,
         maxHeightCells: 24,
         filename: filePath,
       });
+      // Image's text fallback (when terminal lacks inline-image support) does
+      // not respect the rendered width, so a long file path can blow past the
+      // terminal width and crash the host TUI. Wrap the component to truncate
+      // each rendered line to fit.
+      return {
+        invalidate: () => image.invalidate(),
+        render: (width: number) =>
+          image.render(width).map((line) =>
+            visibleWidth(line) > width ? truncateToWidth(line, width) : line,
+          ),
+      };
     } catch {
       return new Text(theme.fg("warning", `Screenshot saved: ${filePath}`), 0, 0);
     }


### PR DESCRIPTION
## Description

The `Image` text-fallback render (used when the terminal lacks inline-image support) does not respect the rendered width. A long screenshot file path can blow past the terminal width and crash the host TUI with a rendering error.

This PR wraps the Image component to truncate each rendered line with `truncateToWidth` so it always fits within the available terminal width.

## Related Issue

N/A — discovered during testing.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor or maintenance
- [ ] Release or packaging change
- [ ] Other:

## Testing

Tested locally with `pi install /path/to/pi-browser-harness` — long screenshot paths no longer crash the TUI. The text fallback renders truncated lines that fit the terminal.

## Checklist

- [x] I ran `npm run typecheck`.
- [x] I ran `npm pack --dry-run` or otherwise verified packaging when package contents changed.
- [x] I tested locally with `pi install /path/to/pi-browser-harness` when runtime behavior changed.
- [ ] I updated README documentation for user-facing changes.
- [ ] I updated CHANGELOG.md for user-facing changes.
- [x] I kept the change focused and avoided unrelated rewrites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Screenshots now render correctly within terminal boundaries, preventing lines from exceeding available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->