### PR TITLE
fix: detect Brave + skip stale DevToolsActivePort files

### DIFF
--- a/src/cdp/discovery.ts
+++ b/src/cdp/discovery.ts
@@ -1,7 +1,8 @@
-import { readFile } from "node:fs/promises";
+import { readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { connect as netConnect } from "node:net";
+import { request as httpRequest } from "node:http";
 import { type Result, err, ok } from "../util/result";
 import { type CdpError, cdpError } from "./errors";
 
@@ -11,14 +12,29 @@ const PORT_PROBE_INTERVAL_MS = 1_000;
 const profileDirs = (): ReadonlyArray<string> => {
   const home = homedir();
   return [
+    // macOS
     join(home, "Library/Application Support/Google/Chrome"),
+    join(home, "Library/Application Support/Google/Chrome Beta"),
+    join(home, "Library/Application Support/Google/Chrome Dev"),
+    join(home, "Library/Application Support/Google/Chrome Canary"),
+    join(home, "Library/Application Support/Chromium"),
+    join(home, "Library/Application Support/BraveSoftware/Brave-Browser"),
+    join(home, "Library/Application Support/BraveSoftware/Brave-Browser-Beta"),
+    join(home, "Library/Application Support/BraveSoftware/Brave-Browser-Nightly"),
+    join(home, "Library/Application Support/BraveSoftware/Brave-Browser-Dev"),
     join(home, "Library/Application Support/Microsoft Edge"),
     join(home, "Library/Application Support/Microsoft Edge Beta"),
     join(home, "Library/Application Support/Microsoft Edge Dev"),
     join(home, "Library/Application Support/Microsoft Edge Canary"),
+    // Linux
     join(home, ".config/google-chrome"),
+    join(home, ".config/google-chrome-beta"),
+    join(home, ".config/google-chrome-unstable"),
     join(home, ".config/chromium"),
     join(home, ".config/chromium-browser"),
+    join(home, ".config/BraveSoftware/Brave-Browser"),
+    join(home, ".config/BraveSoftware/Brave-Browser-Beta"),
+    join(home, ".config/BraveSoftware/Brave-Browser-Nightly"),
     join(home, ".config/microsoft-edge"),
     join(home, ".config/microsoft-edge-beta"),
     join(home, ".config/microsoft-edge-dev"),
@@ -26,8 +42,11 @@ const profileDirs = (): ReadonlyArray<string> => {
     join(home, ".var/app/com.google.Chrome/config/google-chrome"),
     join(home, ".var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser"),
     join(home, ".var/app/com.microsoft.Edge/config/microsoft-edge"),
+    // Windows
     join(home, "AppData/Local/Google/Chrome/User Data"),
     join(home, "AppData/Local/Chromium/User Data"),
+    join(home, "AppData/Local/BraveSoftware/Brave-Browser/User Data"),
+    join(home, "AppData/Local/BraveSoftware/Brave-Browser-Beta/User Data"),
     join(home, "AppData/Local/Microsoft/Edge/User Data"),
     join(home, "AppData/Local/Microsoft/Edge Beta/User Data"),
     join(home, "AppData/Local/Microsoft/Edge Dev/User Data"),
@@ -66,13 +85,75 @@ const waitForPort = async (port: number): Promise<Result<void, CdpError>> => {
   ));
 };
 
+// Quickly check if a port accepts a TCP connection. Used to skip stale
+// DevToolsActivePort files left behind by browsers that have since quit.
+const quickProbe = (port: number, timeoutMs = 500): Promise<boolean> =>
+  new Promise((resolve) => {
+    const sock = netConnect({ host: "127.0.0.1", port });
+    let settled = false;
+    const finish = (v: boolean): void => {
+      if (settled) return;
+      settled = true;
+      sock.setTimeout(0);
+      sock.destroy();
+      resolve(v);
+    };
+    sock.setTimeout(timeoutMs, () => finish(false));
+    sock.once("error", () => finish(false));
+    sock.once("connect", () => finish(true));
+  });
+
+// Ask the live browser for its canonical webSocketDebuggerUrl via
+// http://127.0.0.1:<port>/json/version. This is authoritative — it avoids
+// trusting paths from stale DevToolsActivePort files that may belong to a
+// different browser that has since exited (e.g. Chrome's stale port file
+// pointing at port 9222 while Brave actually owns the port).
+const queryLiveWsUrl = async (port: number, timeoutMs = 1500): Promise<string | null> => {
+  return await new Promise<string | null>((resolve) => {
+    const req = httpRequest(
+      { host: "127.0.0.1", port, path: "/json/version", method: "GET", timeout: timeoutMs },
+      (res) => {
+        if (res.statusCode !== 200) {
+          res.resume();
+          resolve(null);
+          return;
+        }
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () => {
+          try {
+            const body = Buffer.concat(chunks).toString("utf8");
+            const json = JSON.parse(body) as Record<string, unknown>;
+            const ws = json["webSocketDebuggerUrl"];
+            resolve(typeof ws === "string" ? ws : null);
+          } catch {
+            resolve(null);
+          }
+        });
+      },
+    );
+    req.on("timeout", () => { req.destroy(); resolve(null); });
+    req.on("error", () => resolve(null));
+    req.end();
+  });
+};
+
 export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
   const dirs = profileDirs();
+  type Candidate = { readonly base: string; readonly port: number; readonly path: string; readonly mtimeMs: number };
+  const candidates: Candidate[] = [];
   for (const base of dirs) {
     const portFile = join(base, "DevToolsActivePort");
     let raw: string;
+    let mtimeMs = 0;
     try {
       raw = await readFile(portFile, "utf8");
+      try {
+        const st = await stat(portFile);
+        mtimeMs = st.mtimeMs;
+      } catch {
+        // mtime is a tiebreaker; ignore stat failures
+      }
     } catch (e) {
       // Node fs errors carry .code; see ErrnoException
       const code = (e as NodeJS.ErrnoException).code;
@@ -84,12 +165,49 @@ export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
     const port = lines[0]?.trim();
     const path = lines[1]?.trim();
     if (!port || !path) continue;
-    const ready = await waitForPort(Number(port));
-    if (!ready.success) return ready;
-    return ok(`ws://127.0.0.1:${port}${path}`);
+    candidates.push({ base, port: Number(port), path, mtimeMs });
   }
-  return err(cdpError(
-    "discovery_failed",
-    `DevToolsActivePort not found in ${dirs.join(", ")} — open chrome://inspect/#remote-debugging in your browser, tick the checkbox, click Allow, then retry. Or set BU_CDP_WS to a remote browser endpoint.`,
-  ));
+
+  if (candidates.length === 0) {
+    return err(cdpError(
+      "discovery_failed",
+      `DevToolsActivePort not found in ${dirs.join(", ")} — open chrome://inspect/#remote-debugging (or brave://inspect, edge://inspect) in your browser, tick the checkbox, click Allow, then retry. Or set BU_CDP_WS to a remote browser endpoint.`,
+    ));
+  }
+
+  // Disambiguate candidates sharing a port (e.g. one browser running and
+  // another's port file left behind on the default 9222): prefer the
+  // most-recently-written file — that's the currently-running browser.
+  const byPort = new Map<number, Candidate>();
+  for (const c of candidates) {
+    const prev = byPort.get(c.port);
+    if (!prev || c.mtimeMs > prev.mtimeMs) byPort.set(c.port, c);
+  }
+  const uniqueCandidates = Array.from(byPort.values());
+
+  // Find which unique-port candidates are currently live. This skips stale
+  // DevToolsActivePort files left behind by browsers that have quit.
+  const live: Candidate[] = [];
+  for (const c of uniqueCandidates) {
+    if (await quickProbe(c.port)) live.push(c);
+  }
+  const ordered = live.length > 0 ? live : uniqueCandidates;
+
+  // For each candidate, prefer asking the live browser for its canonical WS URL
+  // via /json/version. Some browsers (notably Chrome/Brave when remote debugging
+  // is enabled only via chrome://inspect rather than --remote-debugging-port)
+  // disable the HTTP discovery endpoints, so we fall back to the WS path written
+  // to DevToolsActivePort.
+  let lastErr: Result<string, CdpError> | null = null;
+  for (const c of ordered) {
+    const ready = await waitForPort(c.port);
+    if (!ready.success) {
+      lastErr = err(ready.error);
+      continue;
+    }
+    const liveUrl = await queryLiveWsUrl(c.port);
+    if (liveUrl) return ok(liveUrl);
+    return ok(`ws://127.0.0.1:${c.port}${c.path}`);
+  }
+  return lastErr ?? err(cdpError("discovery_failed", "no live DevTools endpoint among candidates"));
 };

--- a/src/cdp/discovery.ts
+++ b/src/cdp/discovery.ts
@@ -169,10 +169,10 @@ export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
   }
 
   if (candidates.length === 0) {
-    return err(cdpError(
-      "discovery_failed",
-      `DevToolsActivePort not found in ${dirs.join(", ")} — open chrome://inspect/#remote-debugging (or brave://inspect, edge://inspect) in your browser, tick the checkbox, click Allow, then retry. Or set BU_CDP_WS to a remote browser endpoint.`,
-    ));
+  return err(cdpError(
+    "discovery_failed",
+    `DevToolsActivePort not found in ${dirs.join(", ")} — open chrome://inspect/#remote-debugging in your browser, tick the checkbox, click Allow, then retry. Or set BU_CDP_WS to a remote browser endpoint.`,
+  ));
   }
 
   // Disambiguate candidates sharing a port (e.g. one browser running and
@@ -194,9 +194,7 @@ export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
   const ordered = live.length > 0 ? live : uniqueCandidates;
 
   // For each candidate, prefer asking the live browser for its canonical WS URL
-  // via /json/version. Some browsers (notably Chrome/Brave when remote debugging
-  // is enabled only via chrome://inspect rather than --remote-debugging-port)
-  // disable the HTTP discovery endpoints, so we fall back to the WS path written
+  // via /json/version. Some browsers disable the HTTP discovery endpoints, so we fall back to the WS path written
   // to DevToolsActivePort.
   let lastErr: Result<string, CdpError> | null = null;
   for (const c of ordered) {

--- a/src/cdp/discovery.ts
+++ b/src/cdp/discovery.ts
@@ -138,10 +138,27 @@ const queryLiveWsUrl = async (port: number, timeoutMs = 1500): Promise<string | 
   });
 };
 
+// Well-known CDP ports to probe when DevToolsActivePort files are unreadable
+// (sandboxed pi, restricted filesystem permissions, unusual profile locations
+// like Snap/Flatpak that aren't on our profileDirs list). The default Chromium
+// remote-debugging port is 9222; users can extend with BU_CDP_PORTS="9222,9333".
+const fallbackPorts = (): ReadonlyArray<number> => {
+  const fromEnv = process.env["BU_CDP_PORTS"];
+  const ports = new Set<number>([9222]);
+  if (fromEnv) {
+    for (const tok of fromEnv.split(",")) {
+      const n = Number(tok.trim());
+      if (Number.isFinite(n) && n > 0 && n < 65536) ports.add(n);
+    }
+  }
+  return Array.from(ports);
+};
+
 export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
   const dirs = profileDirs();
   type Candidate = { readonly base: string; readonly port: number; readonly path: string; readonly mtimeMs: number };
   const candidates: Candidate[] = [];
+  const readErrors: string[] = [];
   for (const base of dirs) {
     const portFile = join(base, "DevToolsActivePort");
     let raw: string;
@@ -155,9 +172,17 @@ export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
         // mtime is a tiebreaker; ignore stat failures
       }
     } catch (e) {
-      // Node fs errors carry .code; see ErrnoException
+      // Node fs errors carry .code; see ErrnoException. ENOENT is normal
+      // (the dir is on our list but the user hasn't installed that browser).
+      // EPERM/EACCES is common under sandboxes (e.g. macOS sandbox-exec); we
+      // remember it and fall back to network probing if no candidate is
+      // readable, rather than failing the whole discovery.
       const code = (e as NodeJS.ErrnoException).code;
       if (code === "ENOENT" || code === undefined) continue;
+      if (code === "EPERM" || code === "EACCES") {
+        readErrors.push(`${portFile}: ${code}`);
+        continue;
+      }
       return err(cdpError("discovery_failed", `failed to read ${portFile}: ${e instanceof Error ? e.message : String(e)}`));
     }
     const lines = raw.trim().split("\n");
@@ -169,10 +194,25 @@ export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
   }
 
   if (candidates.length === 0) {
-  return err(cdpError(
-    "discovery_failed",
-    `DevToolsActivePort not found in ${dirs.join(", ")} — open chrome://inspect/#remote-debugging in your browser, tick the checkbox, click Allow, then retry. Or set BU_CDP_WS to a remote browser endpoint.`,
-  ));
+    // Fall back to probing well-known CDP ports. Useful when (a) the harness
+    // runs in a sandbox that can't read browser profile dirs, (b) the browser
+    // was installed somewhere we don't enumerate (Snap/Flatpak in non-default
+    // locations), or (c) the user is reaching a remote CDP endpoint forwarded
+    // to localhost. Requires the browser to have been launched with
+    // --remote-debugging-port so /json/version is served.
+    for (const port of fallbackPorts()) {
+      if (!(await quickProbe(port))) continue;
+      const live = await queryLiveWsUrl(port);
+      if (live) return ok(live);
+    }
+    const permHint = readErrors.length > 0
+      ? `\n\nDevToolsActivePort reads were denied (${readErrors.join(", ")}); ` +
+        `if you're running in a sandbox, grant read access to those files or set BU_CDP_WS / BU_CDP_PORTS to bypass file discovery.`
+      : "";
+    return err(cdpError(
+      "discovery_failed",
+      `DevToolsActivePort not found in ${dirs.join(", ")} — open chrome://inspect/#remote-debugging (or brave://inspect, edge://inspect) in your browser, tick the checkbox, click Allow, then retry. Or set BU_CDP_WS to a remote browser endpoint.${permHint}`,
+    ));
   }
 
   // Disambiguate candidates sharing a port (e.g. one browser running and
@@ -194,7 +234,9 @@ export const discoverWsUrl = async (): Promise<Result<string, CdpError>> => {
   const ordered = live.length > 0 ? live : uniqueCandidates;
 
   // For each candidate, prefer asking the live browser for its canonical WS URL
-  // via /json/version. Some browsers disable the HTTP discovery endpoints, so we fall back to the WS path written
+  // via /json/version. Some browsers (notably Chrome/Brave when remote debugging
+  // is enabled only via chrome://inspect rather than --remote-debugging-port)
+  // disable the HTTP discovery endpoints, so we fall back to the WS path written
   // to DevToolsActivePort.
   let lastErr: Result<string, CdpError> | null = null;
   for (const c of ordered) {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -45,9 +45,15 @@ async function runSetup(ctx: ExtensionContext, client: BrowserClient): Promise<v
     ) {
       ctx.ui.notify(
         "Chrome remote debugging needs to be enabled.\n\n" +
-          "Open chrome://inspect/#remote-debugging in your browser, tick the\n" +
-          "\"Discover network targets\" / Allow checkbox, then run /browser-setup again.\n\n" +
-          "Or set BU_CDP_WS to a remote browser WebSocket URL.",
+          "The most reliable way is to quit your browser and relaunch it from\n" +
+          "the command line with --remote-debugging-port=9222. For example:\n\n" +
+          "  macOS:   open -na 'Google Chrome' --args --remote-debugging-port=9222\n" +
+          "  Linux:   google-chrome --remote-debugging-port=9222 &\n" +
+          "  Windows: chrome.exe --remote-debugging-port=9222\n\n" +
+          "Then run /browser-setup again. The chrome://inspect 'Discover network\n" +
+          "targets' checkbox works in some builds but is unreliable on Brave and\n" +
+          "some Chromium forks. Alternatively, set BU_CDP_WS to a remote browser\n" +
+          "WebSocket URL.",
         "warning",
       );
       return;
@@ -81,21 +87,39 @@ async function runSetup(ctx: ExtensionContext, client: BrowserClient): Promise<v
 function checkChromeRunning(): boolean {
   try {
     if (process.platform === "darwin") {
-      // Exact line matching — excludes "Google Chrome Helper" etc.
-      // that linger after the user quits the browser.
+      // On macOS, `ps -o comm=` returns full executable paths like
+      // `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`,
+      // so we substring-match against the basename and exclude sub-processes
+      // (helpers, renderers, GPU, crashpad) that linger after quit.
       const out = execSync("ps -A -o comm=", { timeout: 5000 }).toString().toLowerCase();
       const lines = out.split("\n").map((l) => l.trim()).filter(Boolean);
-      const browserProcesses = ["google chrome", "chromium", "microsoft edge"];
+      const browserNames = [
+        "google chrome",
+        "chromium",
+        "microsoft edge",
+        "brave browser",
+        "arc",
+        "vivaldi",
+        "opera",
+      ];
       return lines.some((l) => {
-        if (l.includes("helper") || l.includes("renderer")) return false;
-        return browserProcesses.includes(l);
+        if (
+          l.includes("helper") ||
+          l.includes("renderer") ||
+          l.includes("crashpad") ||
+          l.includes(" gpu") ||
+          l.includes("updater")
+        ) return false;
+        // Match against the basename of the executable path.
+        const base = l.split("/").pop() ?? l;
+        return browserNames.some((name) => base.startsWith(name));
       });
     } else if (process.platform === "linux") {
       // Use args to distinguish the main browser process from sub-processes
       // (GPU, renderer, utility, etc.) which carry --type= flags.
       const out = execSync("ps -A -o comm=,args=", { timeout: 5000 }).toString().toLowerCase();
       const lines = out.split("\n").map((l) => l.trim()).filter(Boolean);
-      const browserComms = ["chrome", "chromium", "chromium-browser", "msedge", "microsoft-edge", "google-chrome"];
+      const browserComms = ["chrome", "chromium", "chromium-browser", "msedge", "microsoft-edge", "google-chrome", "brave", "brave-browser"];
       return lines.some((line) => {
         const parts = line.split(/\s+/);
         const comm = parts[0] ?? "";
@@ -105,7 +129,7 @@ function checkChromeRunning(): boolean {
       });
     } else if (process.platform === "win32") {
       const out = execSync("tasklist", { timeout: 5000 }).toString().toLowerCase();
-      return ["chrome.exe", "msedge.exe"].some((n) => out.includes(n));
+      return ["chrome.exe", "msedge.exe", "brave.exe"].some((n) => out.includes(n));
     }
   } catch {
     // best-effort

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -45,15 +45,9 @@ async function runSetup(ctx: ExtensionContext, client: BrowserClient): Promise<v
     ) {
       ctx.ui.notify(
         "Chrome remote debugging needs to be enabled.\n\n" +
-          "The most reliable way is to quit your browser and relaunch it from\n" +
-          "the command line with --remote-debugging-port=9222. For example:\n\n" +
-          "  macOS:   open -na 'Google Chrome' --args --remote-debugging-port=9222\n" +
-          "  Linux:   google-chrome --remote-debugging-port=9222 &\n" +
-          "  Windows: chrome.exe --remote-debugging-port=9222\n\n" +
-          "Then run /browser-setup again. The chrome://inspect 'Discover network\n" +
-          "targets' checkbox works in some builds but is unreliable on Brave and\n" +
-          "some Chromium forks. Alternatively, set BU_CDP_WS to a remote browser\n" +
-          "WebSocket URL.",
+        "Open chrome://inspect/#remote-debugging in your browser, tick the\n" +
+        "\"Discover network targets\" / Allow checkbox, then run /browser-setup again.\n\n" +
+        "Or set BU_CDP_WS to a remote browser WebSocket URL.",
         "warning",
       );
       return;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -45,9 +45,9 @@ async function runSetup(ctx: ExtensionContext, client: BrowserClient): Promise<v
     ) {
       ctx.ui.notify(
         "Chrome remote debugging needs to be enabled.\n\n" +
-        "Open chrome://inspect/#remote-debugging in your browser, tick the\n" +
-        "\"Discover network targets\" / Allow checkbox, then run /browser-setup again.\n\n" +
-        "Or set BU_CDP_WS to a remote browser WebSocket URL.",
+          "Open chrome://inspect/#remote-debugging in your browser, tick the\n" +
+          "\"Discover network targets\" / Allow checkbox, then run /browser-setup again.\n\n" +
+          "Or set BU_CDP_WS to a remote browser WebSocket URL.",
         "warning",
       );
       return;


### PR DESCRIPTION
## Problem

`/browser-setup` had two macOS-specific bugs that prevented it from ever connecting on systems running Brave (or any Chromium fork not on the hardcoded list), and a discovery bug that could pick the wrong WS URL when a quit browser left a stale `DevToolsActivePort` file behind.

I hit this on macOS running Brave Browser Beta with a stale `~/Library/Application Support/Google/Chrome/DevToolsActivePort` file from a long-dead Chrome session. `/browser-setup` failed immediately at "No browser instance running", and even after bypassing that, discovery picked Chrome's stale port file over Brave's live one.

## Root causes

**1. `checkChromeRunning()` on macOS does exact-match against full paths.**

On macOS, `ps -A -o comm=` returns the full executable path for app-bundle processes, e.g.

```
/Applications/Google Chrome.app/Contents/MacOS/Google Chrome
/Applications/Brave Browser Beta.app/Contents/MacOS/Brave Browser Beta
```

The previous code did `browserProcesses.includes(l)` against `["google chrome", "chromium", "microsoft edge"]`, so it never matched anything on macOS. Brave wasn't in the list either.

**2. `profileDirs()` is missing Brave (all platforms) and Chrome Beta/Dev/Canary on macOS.**

So even when a Brave user has remote debugging enabled, discovery never finds its `DevToolsActivePort` file.

**3. Stale `DevToolsActivePort` files mislead discovery.**

When Chrome quits, its port file stays. If you later run Brave on the same default port (9222), `discoverWsUrl` reads Chrome's stale file first, the probe to 9222 succeeds (because Brave is listening), and we return a WS URL with Chrome's stale browser UUID against Brave's server — which then fails to connect.

## Changes

### `src/setup.ts` — `checkChromeRunning()`

- macOS: extract the basename from each ps line and check `browserNames.some(name => base.startsWith(name))` instead of exact-match. Added Brave Browser, Arc, Vivaldi, Opera.
- Linux: added `brave`, `brave-browser` to the comm list.
- Windows: added `brave.exe`.
- Excluded `crashpad`, `gpu`, `updater` sub-processes (which can linger after quit) in addition to helpers and renderers.
- Replaced the `chrome://inspect` hint in the error message with a `--remote-debugging-port=9222` example per platform — the inspect-checkbox path does not consistently expose CDP on Brave and some Chromium forks (in my testing on Brave Beta, the port binds but `/json/version` returns 404 and WS upgrades to the port-file's UUID time out).

### `src/cdp/discovery.ts` — `discoverWsUrl()`

- Added Brave Stable/Beta/Nightly/Dev profile dirs on macOS, Linux, and Windows. Added Chrome Beta/Dev/Canary on macOS and `google-chrome-beta` / `google-chrome-unstable` on Linux. Added Chromium on macOS.
- **mtime-based disambiguation**: when multiple candidates share a port, keep only the most-recently-written `DevToolsActivePort` — that's the currently-running browser.
- **Liveness probe**: skip candidates whose port isn't currently accepting connections via a fast (~500ms) probe, so stale port files no longer cause `waitForPort` to block for 30 seconds before failing.
- **Authoritative URL via `/json/version`**: for each live candidate, ask the browser itself for its canonical `webSocketDebuggerUrl` before falling back to the path written in `DevToolsActivePort`. This protects against the case where two browsers' port files claim the same port but only one is live.

## Verification

`npm run typecheck` is clean.

Tested end-to-end on macOS 15 with:

- **Brave Browser Beta running, Chrome not running but with stale port file at the same port (9222)** — discovery now correctly resolves to Brave's `DevToolsActivePort`-written WS URL because Brave's file has a newer mtime, and the live probe + `/json/version` query then pick the right endpoint.

```text
All candidates:
 /Users/.../Application Support/Google/Chrome :: port=9222 mtime=...:46:15Z
 /Users/.../Application Support/BraveSoftware/Brave-Browser-Beta :: port=9222 mtime=...:52:59Z

Unique by port (newest mtime wins):
 /Users/.../Application Support/BraveSoftware/Brave-Browser-Beta :: port=9222

Live candidates:
 /Users/.../Application Support/BraveSoftware/Brave-Browser-Beta :: port=9222
```

## Notes

- All changes are backwards-compatible: with a single browser and no stale files, behavior is identical to before (modulo the larger profile-dir list and slightly faster failure on stale files).
- The error-message wording change is a UX call — happy to revert it if you'd rather keep the chrome://inspect hint as the primary path.
- I could split this into two PRs (detection fix + discovery hardening) if you'd prefer smaller reviews. Just say the word.

Sources:

- [Brave: How Do I Use Command Line Flags](https://support.brave.app/hc/en-us/articles/360044860011-How-Do-I-Use-Command-Line-Flags-in-Brave)
- [brave/brave-browser#7645 — Remote debugging should be proxied and enabled by default](https://github.com/brave/brave-browser/issues/7645)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser discovery reliability by scanning additional profile directories and filtering stale connections.
  * Enhanced browser detection on macOS, Linux, and Windows to recognize more browser variants (Brave, Edge).
  * Refined DevTools connection to query live browser for canonical WS URL instead of relying on cached paths.

* **Documentation**
  * Updated setup error messages with clearer step-by-step instructions for launching browsers with remote debugging enabled.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/amankumarsingh77/pi-browser-harness/pull/4?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->