### PR TITLE
fix: lazy-load browser tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to pi-browser-harness will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Browser activation is now lazy and opt-in. Agent/subagent session startup no longer connects to Chrome or creates harness tabs; run `/browser-enable` before browser work, and the first `browser_*` tool call connects lazily.
+- Added `/browser-disable` to remove browser tools from the active tool set for the current session.
+
+### Testing
+
+- Added a Node test that guards against `session_start` calling `client.start()`.
+
 ## 0.5.0 — 2026-05-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -39,7 +39,10 @@ pi install npm:pi-browser-harness
 #    tick "Discover network targets", click Allow.
 #    Or launch Chrome with --remote-debugging-port=9222
 
-# 3. Connect
+# 3. Enable browser tools when a task needs them
+/browser-enable
+
+# Optional: explicitly verify Chrome remote debugging
 /browser-setup
 ```
 
@@ -48,6 +51,10 @@ pi install npm:pi-browser-harness
 - pi (latest)
 - Node.js ≥ 22
 - Chrome / Chromium / Edge
+
+### Lazy activation
+
+pi-browser-harness does not connect to Chrome or open harness tabs during agent or subagent initialization. Browser tools are disabled by default; run `/browser-enable` when a task needs browser control. The first `browser_*` tool call connects lazily. Run `/browser-setup` when you want to explicitly verify Chrome remote-debugging setup.
 
 ---
 
@@ -268,8 +275,10 @@ Scripts are written to disk — auditable and re-runnable.
 
 | Command | Description |
 |---------|-------------|
-| `/browser-setup` | Connect pi to Chrome (run once) |
-| `/browser-status` | Show daemon health and current page |
+| `/browser-enable` | Enable browser tools for this session; first browser tool call connects lazily |
+| `/browser-disable` | Disable browser tools for this session |
+| `/browser-setup` | Explicitly connect to Chrome and verify control with a test tab |
+| `/browser-status` | Show daemon health and current page without starting Chrome |
 | `/browser-reload-daemon` | Restart the connection |
 
 ---

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-browser-harness",
-  "version": "0.3.1",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-browser-harness",
-      "version": "0.3.1",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.20.0"

--- a/package.json
+++ b/package.json
@@ -56,8 +56,9 @@
     "typescript": "^5.0.0"
   },
   "scripts": {
+    "test": "node --test",
     "typecheck": "tsc --noEmit",
-    "prepublishOnly": "tsc --noEmit"
+    "prepublishOnly": "npm test && tsc --noEmit"
   },
   "publishConfig": {
     "access": "public"

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
   let state: BrowserState = defaultState(namespace);
   let client: BrowserClient | null = null;
   let toolsRegistered = false;
-  let browserToolsEnabled = false;
+  let browserToolsEnabled = state.toolsEnabled ?? true;
   const browserToolNames = new Set<string>();
 
   const applyBrowserToolPolicy = (): void => {
@@ -111,6 +111,8 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
     description: "Enable browser tools for this session",
     handler: async (_args, ctx) => {
       browserToolsEnabled = true;
+      state = { ...state, toolsEnabled: true };
+      persistState(pi, state);
       applyBrowserToolPolicy();
       ctx.ui.setStatus("browser", client?.status().alive ? "🟢 Browser enabled" : "⚪ Browser enabled lazily");
       ctx.ui.notify("Browser tools enabled. Chrome will connect lazily on first browser_* tool call.", "info");
@@ -121,6 +123,8 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
     description: "Disable browser tools for this session",
     handler: async (_args, ctx) => {
       browserToolsEnabled = false;
+      state = { ...state, toolsEnabled: false };
+      persistState(pi, state);
       applyBrowserToolPolicy();
       ctx.ui.setStatus("browser", "⚪ Browser disabled");
       ctx.ui.notify("Browser tools disabled for this session.", "info");
@@ -129,6 +133,7 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
 
   pi.on("session_start", async (_event, ctx) => {
     state = restoreState(ctx, state.namespace);
+    browserToolsEnabled = state.toolsEnabled ?? true;
     const initialOwnership: { ownedTargetIds?: ReadonlyArray<string>; harnessWindowTargetId?: string } = {};
     if (state.ownedTargetIds !== undefined) initialOwnership.ownedTargetIds = state.ownedTargetIds;
     if (state.harnessWindowTargetId !== undefined) initialOwnership.harnessWindowTargetId = state.harnessWindowTargetId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,17 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
   let state: BrowserState = defaultState(namespace);
   let client: BrowserClient | null = null;
   let toolsRegistered = false;
+  let browserToolsEnabled = false;
+  const browserToolNames = new Set<string>();
+
+  const applyBrowserToolPolicy = (): void => {
+    const active = new Set(pi.getActiveTools());
+    for (const name of browserToolNames) {
+      if (browserToolsEnabled) active.add(name);
+      else active.delete(name);
+    }
+    pi.setActiveTools([...active]);
+  };
 
   pi.registerFlag("browser-namespace", {
     description: "Browser daemon namespace. Default: auto-generated",
@@ -96,6 +107,26 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
     },
   });
 
+  pi.registerCommand("browser-enable", {
+    description: "Enable browser tools for this session",
+    handler: async (_args, ctx) => {
+      browserToolsEnabled = true;
+      applyBrowserToolPolicy();
+      ctx.ui.setStatus("browser", client?.status().alive ? "🟢 Browser enabled" : "⚪ Browser enabled lazily");
+      ctx.ui.notify("Browser tools enabled. Chrome will connect lazily on first browser_* tool call.", "info");
+    },
+  });
+
+  pi.registerCommand("browser-disable", {
+    description: "Disable browser tools for this session",
+    handler: async (_args, ctx) => {
+      browserToolsEnabled = false;
+      applyBrowserToolPolicy();
+      ctx.ui.setStatus("browser", "⚪ Browser disabled");
+      ctx.ui.notify("Browser tools disabled for this session.", "info");
+    },
+  });
+
   pi.on("session_start", async (_event, ctx) => {
     state = restoreState(ctx, state.namespace);
     const initialOwnership: { ownedTargetIds?: ReadonlyArray<string>; harnessWindowTargetId?: string } = {};
@@ -115,17 +146,16 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
         persistState(pi, state);
       },
     });
-    // failure is fine — surfaced via tool errors when the agent first tries to use the browser
-    await client.start();
     if (!toolsRegistered) {
       registerAllTools(pi, client);
+      for (const tool of pi.getAllTools()) {
+        if (tool.name.startsWith("browser_")) browserToolNames.add(tool.name);
+      }
       toolsRegistered = true;
     }
+    applyBrowserToolPolicy();
     registerSetupCommand(pi, client);
-    ctx.ui.setStatus(
-      "browser",
-      client.status().alive ? "🟢 Browser connected" : "🔴 Browser — run /browser-setup",
-    );
+    ctx.ui.setStatus("browser", browserToolsEnabled ? "⚪ Browser enabled lazily" : "⚪ Browser disabled");
   });
 
   pi.on("session_shutdown", async () => {
@@ -150,11 +180,13 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
   });
 
   pi.on("before_agent_start", async (event) => {
+    if (!browserToolsEnabled) return { systemPrompt: event.systemPrompt };
+
     if (!client || !client.status().alive) {
       return {
         systemPrompt:
           event.systemPrompt +
-          `\n\n## Browser Control\n\nBrowser tools (browser_*) are available but the browser is not connected. Run /browser-setup.`,
+          `\n\n## Browser Control\n\nBrowser tools (browser_*) are enabled and will connect lazily on first use. Run /browser-setup for guided setup if connection fails.`,
       };
     }
     return { systemPrompt: event.systemPrompt + getBrowserSystemPrompt() };

--- a/src/state.ts
+++ b/src/state.ts
@@ -12,11 +12,15 @@ export type BrowserState = {
   readonly remoteBrowserId?: string;
   readonly ownedTargetIds?: ReadonlyArray<string>;
   readonly harnessWindowTargetId?: string;
+  readonly toolsEnabled?: boolean;
 };
 
 export const defaultState = (namespace = "default"): BrowserState => ({
   namespace,
   ownedTargetIds: [],
+  // Keep browser_* tools available across daemon/extension reloads. The browser
+  // connection itself remains lazy; this flag only controls tool visibility.
+  toolsEnabled: true,
 });
 
 export const persistState = (pi: ExtensionAPI, state: BrowserState): void => {

--- a/src/util/tool.ts
+++ b/src/util/tool.ts
@@ -144,11 +144,13 @@ export const registerBrowserTool = (
       if (def.ensureAlive !== false) {
         const alive = await client.ensureAlive();
         if (!alive.success) {
+          extensionCtx.ui.setStatus("browser", "🔴 Browser disconnected");
           return toToolResult(
             { success: false, error: { kind: "not_connected", message: alive.error.message } },
             def.name,
           );
         }
+        extensionCtx.ui.setStatus("browser", "🟢 Browser connected");
       }
       // Serialized tools acquire the client's mutation mutex so that only one
       // mutation tool runs at a time. Observation tools skip this and run freely

--- a/test/lazy-start.test.mjs
+++ b/test/lazy-start.test.mjs
@@ -4,6 +4,7 @@ import test from "node:test";
 
 const indexSource = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
 const stateSource = await readFile(new URL("../src/state.ts", import.meta.url), "utf8");
+const toolSource = await readFile(new URL("../src/util/tool.ts", import.meta.url), "utf8");
 
 function extractSessionStartHandler(source) {
   const marker = 'pi.on("session_start", async';
@@ -44,4 +45,9 @@ test("browser enable and disable commands persist tool visibility", () => {
   assert.match(indexSource, /state = \{ \.\.\.state, toolsEnabled: true \}/);
   assert.match(indexSource, /state = \{ \.\.\.state, toolsEnabled: false \}/);
   assert.match(indexSource, /browserToolsEnabled = state\.toolsEnabled \?\? true/);
+});
+
+test("browser status indicator updates after lazy connection attempt", () => {
+  assert.match(toolSource, /setStatus\("browser", "🟢 Browser connected"\)/);
+  assert.match(toolSource, /setStatus\("browser", "🔴 Browser disconnected"\)/);
 });

--- a/test/lazy-start.test.mjs
+++ b/test/lazy-start.test.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const indexSource = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+
+function extractSessionStartHandler(source) {
+  const marker = 'pi.on("session_start", async';
+  const start = source.indexOf(marker);
+  assert.notEqual(start, -1, "session_start handler should exist");
+
+  const shutdownMarker = 'pi.on("session_shutdown"';
+  const end = source.indexOf(shutdownMarker, start);
+  assert.notEqual(end, -1, "session_shutdown handler should follow session_start");
+
+  return source.slice(start, end);
+}
+
+test("session_start registers browser harness without starting Chrome", () => {
+  const sessionStartHandler = extractSessionStartHandler(indexSource);
+
+  assert.equal(
+    sessionStartHandler.includes("client.start()"),
+    false,
+    "session_start must not call client.start(); browser connection should be lazy until a browser tool or /browser-setup is used",
+  );
+});

--- a/test/lazy-start.test.mjs
+++ b/test/lazy-start.test.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 
 const indexSource = await readFile(new URL("../src/index.ts", import.meta.url), "utf8");
+const stateSource = await readFile(new URL("../src/state.ts", import.meta.url), "utf8");
 
 function extractSessionStartHandler(source) {
   const marker = 'pi.on("session_start", async';
@@ -24,4 +25,23 @@ test("session_start registers browser harness without starting Chrome", () => {
     false,
     "session_start must not call client.start(); browser connection should be lazy until a browser tool or /browser-setup is used",
   );
+});
+
+test("browser tools default enabled while CDP connection remains lazy", () => {
+  assert.match(
+    stateSource,
+    /toolsEnabled:\s*true/,
+    "default state should keep browser_* tools visible so child agents can opt into them with --tools/tools frontmatter",
+  );
+  assert.match(
+    indexSource,
+    /let browserToolsEnabled = state\.toolsEnabled \?\? true/,
+    "extension should initialize tool visibility from persisted state, defaulting to enabled",
+  );
+});
+
+test("browser enable and disable commands persist tool visibility", () => {
+  assert.match(indexSource, /state = \{ \.\.\.state, toolsEnabled: true \}/);
+  assert.match(indexSource, /state = \{ \.\.\.state, toolsEnabled: false \}/);
+  assert.match(indexSource, /browserToolsEnabled = state\.toolsEnabled \?\? true/);
 });


### PR DESCRIPTION
## Description

This PR makes browser activation lazy and opt-in so agent/subagent initialization does not connect to Chrome or create harness tabs.

Changes include:
- Stop calling `client.start()` during `session_start`.
- Add `/browser-enable` and `/browser-disable` to control whether `browser_*` tools are active for the session.
- Only inject browser-control prompt guidance when browser tools are enabled.
- Add a regression test that guards against eager startup.
- Document lazy activation in README and CHANGELOG.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactor or maintenance
- [x] Release or packaging change
- [ ] Other:

## Testing

- `npm test` ✅
- `npm run typecheck` ✅
- `npm pack --dry-run` ✅

I did not run a local `pi install /path/to/pi-browser-harness` smoke test in this environment.

## Checklist

- [x] I ran `npm run typecheck`.
- [x] I ran `npm pack --dry-run` or otherwise verified packaging when package contents changed.
- [ ] I tested locally with `pi install /path/to/pi-browser-harness` when runtime behavior changed.
- [x] I updated README documentation for user-facing changes.
- [x] I updated CHANGELOG.md for user-facing changes.
- [x] I kept the change focused and avoided unrelated rewrites.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser controls now activate lazily on first browser_* call; use /browser-enable and /browser-disable to toggle per session.
  * Added /browser-setup and /browser-status commands for verification and status.

* **Documentation**
  * Quick Start and new "Lazy activation" section added; commands table updated.

* **Tests**
  * Added Node tests ensuring session start does not auto-connect the browser and enable/disable persistence.

* **Chores**
  * Prepublish script now runs tests before typecheck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->