### PR TITLE
fix: remove browser footer status indicator (#10)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -144,10 +144,6 @@ export default function browserHarnessExtension(pi: ExtensionAPI): void {
     }
     registerSetupCommand(pi, client);
     registerDeepResearchCommand(pi);
-    ctx.ui.setStatus(
-      "browser",
-      client.status().alive ? "🟢 Browser connected" : "🔴 Browser — run /browser-setup",
-    );
   });
 
   pi.on("session_shutdown", async () => {


### PR DESCRIPTION
Fixes #10.

## Problem
The footer status chip was set during `session_start` in `src/index.ts`:

```ts
ctx.ui.setStatus("browser", client.status().alive ? "🟢 Browser connected" : "🔴 Browser — run /browser-setup");
```

But the `/browser-setup` command handler in `src/setup.ts` only calls `ctx.ui.notify(...)` — it never updates `ctx.ui.setStatus(...)` after `performSetup()` connects the client. So after a successful setup the footer kept showing the stale red `🔴 Browser — run /browser-setup` nudge even though the browser was connected.

## Fix
Remove the footer status indicator entirely rather than syncing it from the setup handler. Browser control is on-demand, and the `/browser-setup` command already reports its outcome via `notify()`, so the persistent footer chip added no value and only introduced the stale-state bug.

## Testing
- `npx tsc --noEmit` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the browser connection status message during session startup.
  * Browser tools and commands continue to be registered as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->