### PR TITLE
fix: reconnect to Chrome only on explicit browser demand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to pi-browser-harness will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- **Chrome remote-debugging consent is no longer retriggered indefinitely in the background.** A cancelled, failed, or disconnected CDP connection now remains disconnected until the next explicit browser request, which makes one on-demand connection attempt instead of running an unbounded retry loop that can repeatedly interrupt normal browsing.
+
 ## 0.11.0 — 2026-08-02
 
 ### Fixed

--- a/src/daemon/bridge.ts
+++ b/src/daemon/bridge.ts
@@ -446,7 +446,8 @@ export const createCdpBridge = (options: CdpBridgeDependencies = {}): CdpBridge 
     clientId: string,
     send: SendToClient,
   ): Promise<void> => {
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
+    let activeSocket = ws;
+    if (!activeSocket || activeSocket.readyState !== WebSocket.OPEN) {
       // Connection attempts happen only in response to explicit browser work.
       tryConnect();
       const ready = await waitForConnection();
@@ -458,6 +459,16 @@ export const createCdpBridge = (options: CdpBridgeDependencies = {}): CdpBridge 
         });
         return;
       }
+    }
+
+    activeSocket = ws;
+    if (!activeSocket || activeSocket.readyState !== WebSocket.OPEN) {
+      send(clientId, {
+        type: "response",
+        id: req.id,
+        error: { code: -32000, message: "Chrome not connected" },
+      });
+      return;
     }
 
     const isDetach = req.method === "Target.detachFromTarget";
@@ -488,7 +499,7 @@ export const createCdpBridge = (options: CdpBridgeDependencies = {}): CdpBridge 
     if (req.sessionId) payload["sessionId"] = req.sessionId;
 
     try {
-      ws.send(JSON.stringify(payload));
+      activeSocket.send(JSON.stringify(payload));
     } catch (e) {
       mux.take(daemonId);
       generations.delete(daemonId);

--- a/src/daemon/bridge.ts
+++ b/src/daemon/bridge.ts
@@ -299,6 +299,9 @@ export const createCdpBridge = (options: CdpBridgeDependencies = {}): CdpBridge 
         if (ws === sock) ws = null;
         wsUrl = null;
         connecting = false;
+        // Not via settleAttempt: a connection that opened already settled its attempt, so
+        // its requests would otherwise hang to the command timeout instead of failing now.
+        rejectAttemptCallbacks(generation);
         if (notifyClose) closeHandler?.();
         settleAttempt();
       };

--- a/src/daemon/bridge.ts
+++ b/src/daemon/bridge.ts
@@ -5,6 +5,8 @@ import type { CdpRawMessage } from "../cdp/types";
 import type { WireRequest, WireResponse, WireEvent } from "./protocol";
 import { CDP_CONNECT_TIMEOUT_MS, CDP_COMMAND_TIMEOUT_MS } from "./protocol";
 import { asString, isRecord } from "../util/guards";
+import type { CdpError } from "../cdp/errors";
+import type { Result } from "../util/result";
 
 export type SendToClient = (clientId: string, msg: WireResponse | WireEvent) => void;
 
@@ -117,9 +119,22 @@ export const createEventRouter = (): EventRouter => {
   };
 };
 
-const CONNECT_WAIT_MS = 15_000;
+type CdpBridgeDependencies = {
+  discoverWsUrl?: () => Promise<Result<string, CdpError>>;
+  createWebSocket?: (url: string) => WebSocket;
+  connectTimeoutMs?: number;
+  onAttemptSettled?: () => void;
+};
 
-export const createCdpBridge = (): CdpBridge => {
+export const createCdpBridge = (options: CdpBridgeDependencies = {}): CdpBridge => {
+  const {
+    discoverWsUrl: discoverWsUrlImpl = discoverWsUrl,
+    createWebSocket: createWebSocketImpl = (url: string): WebSocket =>
+      new WebSocket(url, { perMessageDeflate: false }),
+    connectTimeoutMs = CDP_CONNECT_TIMEOUT_MS,
+    onAttemptSettled,
+  } = options;
+
   let ws: WebSocket | null = null;
   let wsUrl: string | null = null;
   const mux = createIdMultiplexer();
@@ -127,23 +142,15 @@ export const createCdpBridge = (): CdpBridge => {
   let eventHandler: EventHandler | null = null;
   let closeHandler: CloseHandler | null = null;
 
-  const connectedWaiters: Array<() => void> = [];
-  const signalConnected = (): void => {
-    for (const w of connectedWaiters.splice(0)) w();
-  };
+  // daemonId -> { generation, clientId }: lets a failed attempt reject only its own
+  // in-flight requests, and a gone client's entries be dropped without late answers.
+  const generations = new Map<number, { generation: number; clientId: string }>();
 
-  const waitForConnection = (timeoutMs: number): Promise<void> =>
-    new Promise((resolve) => {
-      let settled = false;
-      const finish = (): void => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timer);
-        resolve();
-      };
-      const timer = setTimeout(finish, timeoutMs);
-      connectedWaiters.push(finish);
-    });
+  let stopped = false;
+  let connecting = false;
+  let attemptGeneration = 0;
+  let activeAttempt = 0;
+  let activeSocket: WebSocket | null = null;
 
   const onChromeMessage = (raw: string): void => {
     let parsed: unknown;
@@ -152,6 +159,7 @@ export const createCdpBridge = (): CdpBridge => {
     const msg: CdpRawMessage = parsed;
 
     if (msg.id !== undefined) {
+      generations.delete(msg.id);
       const cb = mux.take(msg.id);
       if (!cb) return;
       const localId = cb.localId;
@@ -195,98 +203,212 @@ export const createCdpBridge = (): CdpBridge => {
     }
   };
 
-  let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
-  let reconnectAttempt = 0;
-  let stopped = false;
+  const rejectCallbacksWhere = (
+    pred: (info: { generation: number; clientId: string }) => boolean,
+  ): void => {
+    for (const [daemonId, info] of generations) {
+      if (!pred(info)) continue;
+      generations.delete(daemonId);
+      const cb = mux.take(daemonId);
+      if (!cb) continue;
+      cb.send(cb.clientId, {
+        type: "response",
+        id: cb.localId,
+        error: { code: -32000, message: "Chrome disconnected" },
+      });
+    }
+  };
 
+  const rejectAttemptCallbacks = (generation: number): void => {
+    rejectCallbacksWhere((info) => info.generation === generation);
+  };
+
+  const rejectAllPendingCallbacks = (): void => {
+    rejectCallbacksWhere(() => true);
+  };
+
+  const closeSocket = (socket: WebSocket): void => {
+    try {
+      socket.close();
+    } catch {}
+  };
+
+  const isCurrentAttempt = (generation: number): boolean =>
+    generation === activeAttempt && !stopped;
+
+  const isCurrentAttemptSocket = (generation: number, socket: WebSocket): boolean =>
+    isCurrentAttempt(generation) && activeSocket === socket;
+
+  const clearActiveAttempt = (generation: number): void => {
+    if (activeAttempt === generation) {
+      activeAttempt = 0;
+      activeSocket = null;
+    }
+  };
+
+  // On-demand Chrome connection. Attempts happen only from start() and from
+  // handleRequest() while disconnected; a failed or disconnected bridge stays
+  // disconnected until the next explicit browser demand. No background retry loop.
   const tryConnect = (): void => {
-    if (stopped) return;
-    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
+    if (stopped || connecting || (ws && ws.readyState === WebSocket.OPEN)) return;
+
+    const generation = ++attemptGeneration;
+    activeAttempt = generation;
+    connecting = true;
 
     const attempt = async (): Promise<void> => {
-      if (ws && ws.readyState === WebSocket.OPEN) return;
+      let settled = false;
+      let sock: WebSocket | null = null;
+      let timeout: ReturnType<typeof setTimeout> | null = null;
+      let settleAttempt: () => void = () => {};
 
-      const cachedUrl = wsUrl;
-      let url: string;
-      if (cachedUrl === null || cachedUrl === "" || reconnectAttempt > 0) {
-        const d = await discoverWsUrl();
-        if (!d.success) { scheduleRetry(); return; }
-        url = d.data;
-        wsUrl = url;
-      } else {
-        url = cachedUrl;
-      }
-
-      const settledPromise = new Promise<void>((settle) => {
-        let settled = false;
-        const settleOnce = (): void => {
+      const settledPromise = new Promise<void>((resolve) => {
+        settleAttempt = (): void => {
           if (settled) return;
           settled = true;
-          settle();
+          if (timeout) {
+            clearTimeout(timeout);
+            timeout = null;
+          }
+          if (generation === activeAttempt && !stopped) {
+            wsUrl = null;
+            connecting = false;
+          }
+          rejectAttemptCallbacks(generation);
+          onAttemptSettled?.();
+          resolve();
         };
+      });
 
-        let sock: WebSocket;
-        try {
-          sock = new WebSocket(url, { perMessageDeflate: false });
-        } catch {
-          scheduleRetry();
+      const clearAttemptTimeout = (): void => {
+        if (timeout) {
+          clearTimeout(timeout);
+          timeout = null;
+        }
+      };
+
+      const failCurrentAttempt = (notifyClose: boolean): void => {
+        clearAttemptTimeout();
+        const isCurrent = isCurrentAttempt(generation);
+        if (!isCurrent) {
+          rejectAttemptCallbacks(generation);
           return;
         }
 
-        const timer = setTimeout(() => {
-          sock.close();
-          settleOnce();
-        }, CDP_CONNECT_TIMEOUT_MS);
+        clearActiveAttempt(generation);
+        if (ws === sock) ws = null;
+        wsUrl = null;
+        connecting = false;
+        if (notifyClose) closeHandler?.();
+        settleAttempt();
+      };
 
-        sock.on("open", () => {
-          clearTimeout(timer);
-          ws = sock;
-          reconnectAttempt = 0;
-          ws.send(JSON.stringify({ id: 0, method: "Target.setDiscoverTargets", params: { discover: true } }));
-          console.log("[pi-browser-daemon] Connected to Chrome ✓");
-          signalConnected();
-          settleOnce();
-        });
+      timeout = setTimeout(() => {
+        if (!isCurrentAttempt(generation) || stopped) {
+          failCurrentAttempt(false);
+          return;
+        }
 
-        sock.on("message", (data: WebSocket.Data) => {
-          onChromeMessage(typeof data === "string" ? data : data.toString());
-        });
+        if (sock && sock.readyState !== WebSocket.CLOSED) {
+          closeSocket(sock);
+        }
+        failCurrentAttempt(true);
+      }, connectTimeoutMs);
 
-        sock.on("error", () => {
-          clearTimeout(timer);
-          settleOnce();
-        });
-
-        sock.on("close", () => {
-          clearTimeout(timer);
-          ws = null;
-          for (const cb of mux.takeAll()) {
-            cb.send(cb.clientId, {
-              type: "response",
-              id: cb.localId,
-              error: { code: -32000, message: "Chrome disconnected" },
-            });
-          }
-          closeHandler?.();
-          scheduleRetry();
-        });
-      });
-
-      await settledPromise;
-      if (!ws || ws.readyState !== WebSocket.OPEN) {
-        scheduleRetry();
+      let url = wsUrl;
+      if (!url) {
+        const d = await discoverWsUrlImpl();
+        if (!isCurrentAttempt(generation) || stopped) {
+          failCurrentAttempt(false);
+          return;
+        }
+        if (!d.success) {
+          failCurrentAttempt(false);
+          return;
+        }
+        url = d.data;
       }
+
+      if (!isCurrentAttempt(generation) || stopped) {
+        failCurrentAttempt(false);
+        return;
+      }
+
+      try {
+        sock = createWebSocketImpl(url);
+      } catch {
+        failCurrentAttempt(false);
+        return;
+      }
+
+      if (!isCurrentAttempt(generation) || stopped) {
+        closeSocket(sock);
+        failCurrentAttempt(false);
+        return;
+      }
+
+      wsUrl = url;
+      activeSocket = sock;
+
+      const onOpen = (): void => {
+        if (!sock || !isCurrentAttemptSocket(generation, sock)) {
+          clearAttemptTimeout();
+          if (sock && sock.readyState !== WebSocket.CLOSED) {
+            closeSocket(sock);
+          }
+          failCurrentAttempt(false);
+          return;
+        }
+
+        clearAttemptTimeout();
+        ws = sock;
+        try {
+          ws.send(JSON.stringify({ id: 0, method: "Target.setDiscoverTargets", params: { discover: true } }));
+        } catch {
+          failCurrentAttempt(true);
+          if (sock.readyState !== WebSocket.CLOSED) {
+            closeSocket(sock);
+          }
+          return;
+        }
+        console.log("[pi-browser-daemon] Connected to Chrome ✓");
+        settleAttempt();
+      };
+
+      const onMessage = (data: WebSocket.Data): void => {
+        if (!sock || !isCurrentAttemptSocket(generation, sock)) return;
+        onChromeMessage(typeof data === "string" ? data : data.toString());
+      };
+
+      const onError = (): void => {
+        clearAttemptTimeout();
+        const notifyClose = !!sock && isCurrentAttemptSocket(generation, sock);
+        failCurrentAttempt(notifyClose);
+        if (sock && sock.readyState !== WebSocket.CLOSED) {
+          closeSocket(sock);
+        }
+      };
+
+      const onClose = (): void => {
+        clearAttemptTimeout();
+        const notifyClose = !!sock && isCurrentAttemptSocket(generation, sock);
+        failCurrentAttempt(notifyClose);
+      };
+
+      sock.on("open", onOpen);
+      sock.on("message", onMessage);
+      sock.on("error", onError);
+      sock.on("close", onClose);
+
+      // The promise must always settle even on constructor errors.
+      await settledPromise;
     };
 
-    attempt().catch(() => scheduleRetry());
-  };
-
-  const scheduleRetry = (): void => {
-    if (stopped) return;
-    const delay = Math.min(1000 * Math.pow(2, Math.min(reconnectAttempt, 6)), 60_000);
-    reconnectAttempt++;
-    wsUrl = null;
-    reconnectTimer = setTimeout(tryConnect, delay);
+    attempt().catch(() => {
+      if (isCurrentAttempt(generation)) {
+        connecting = false;
+      }
+    });
   };
 
   const start = async (): Promise<void> => {
@@ -296,11 +418,27 @@ export const createCdpBridge = (): CdpBridge => {
 
   const stop = async (): Promise<void> => {
     stopped = true;
-    if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }
-    mux.takeAll();
-    signalConnected();
-    if (ws) { try { ws.close(1000, "Shutdown"); } catch {} ws = null; }
+    attemptGeneration += 1;
+    activeAttempt = 0;
+    activeSocket = null;
+    connecting = false;
+    rejectAllPendingCallbacks();
+    if (ws) {
+      try {
+        ws.close(1000, "Shutdown");
+      } catch {}
+      ws = null;
+    }
     wsUrl = null;
+  };
+
+  const waitForConnection = async (): Promise<boolean> => {
+    const deadline = Date.now() + connectTimeoutMs;
+    while (connecting && Date.now() < deadline) {
+      if (ws && ws.readyState === WebSocket.OPEN) return true;
+      await new Promise((r) => setTimeout(r, 5));
+    }
+    return ws !== null && ws.readyState === WebSocket.OPEN;
   };
 
   const handleRequest = async (
@@ -308,26 +446,31 @@ export const createCdpBridge = (): CdpBridge => {
     clientId: string,
     send: SendToClient,
   ): Promise<void> => {
-    // Every queued request awaits the same connect signal rather than each spinning its own poll loop.
-    if (!ws || ws.readyState !== WebSocket.OPEN) await waitForConnection(CONNECT_WAIT_MS);
-
     if (!ws || ws.readyState !== WebSocket.OPEN) {
-      send(clientId, {
-        type: "response",
-        id: req.id,
-        error: { code: -32000, message: "Chrome not connected" },
-      });
-      return;
+      // Connection attempts happen only in response to explicit browser work.
+      tryConnect();
+      const ready = await waitForConnection();
+      if (!ready) {
+        send(clientId, {
+          type: "response",
+          id: req.id,
+          error: { code: -32000, message: "Chrome not connected" },
+        });
+        return;
+      }
     }
 
     const isDetach = req.method === "Target.detachFromTarget";
     if (isDetach && req.sessionId) router.release(req.sessionId);
 
+    const isAttach = req.method === "Target.attachToTarget";
+
     const daemonId = mux.allocate(
-      { clientId, localId: req.id, send, isAttach: req.method === "Target.attachToTarget" },
+      { clientId, localId: req.id, send, isAttach },
       (id) =>
         setTimeout(() => {
           mux.take(id);
+          generations.delete(id);
           send(clientId, {
             type: "response",
             id: req.id,
@@ -335,6 +478,7 @@ export const createCdpBridge = (): CdpBridge => {
           });
         }, CDP_COMMAND_TIMEOUT_MS),
     );
+    generations.set(daemonId, { generation: attemptGeneration, clientId });
 
     const payload: Record<string, unknown> = {
       id: daemonId,
@@ -347,6 +491,7 @@ export const createCdpBridge = (): CdpBridge => {
       ws.send(JSON.stringify(payload));
     } catch (e) {
       mux.take(daemonId);
+      generations.delete(daemonId);
       send(clientId, {
         type: "response",
         id: req.id,
@@ -361,7 +506,11 @@ export const createCdpBridge = (): CdpBridge => {
     handleRequest,
     isAlive: () => ws !== null && ws.readyState === WebSocket.OPEN,
     getSessionOwner: (sid) => router.getOwner(sid),
-    removeClient: (cid) => { mux.clearClient(cid); router.removeClient(cid); },
+    removeClient: (cid) => {
+      rejectCallbacksWhere((info) => info.clientId === cid);
+      mux.clearClient(cid);
+      router.removeClient(cid);
+    },
     onEvent: (h) => { eventHandler = h; },
     onClose: (h) => { closeHandler = h; },
   };

--- a/test/daemon/bridge-connection-test.ts
+++ b/test/daemon/bridge-connection-test.ts
@@ -4,12 +4,12 @@
  * Covers remaining lifecycle regressions after PR #18:
  *  1. discovery must be bounded by `connectTimeoutMs`
  *  2. handleRequest should stop waiting as soon as the active attempt settles
- *  3. stop() must resolve pending callbacks before clearing state
+ *  3. stop() and a dropped connection must resolve pending callbacks
  *  4. constructor and stale-generation cleanup still must reject old callbacks
- *
- * Run: npx tsx test/manual/bridge-reconnect-regression-test.ts
  */
 
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import type { WireRequest, WireResponse } from "../../src/daemon/protocol";
 import type { CdpError } from "../../src/cdp/errors";
@@ -21,16 +21,8 @@ type ParsedSend = { id?: number; method?: string };
 type Discover = () => Promise<Result<string, CdpError>>;
 type SendResult = WireResponse;
 
-let passed = 0;
-let failed = 0;
 const check = (cond: boolean, label: string): void => {
-  if (cond) {
-    passed++;
-    console.log(`  ✓ ${label}`);
-  } else {
-    failed++;
-    console.error(`  ✗ ${label}`);
-  }
+  assert.ok(cond, label);
 };
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
@@ -307,7 +299,59 @@ const testStopRejectsPendingRequestCallbacks = async (): Promise<void> => {
   );
 };
 
-// --- Test 5: stale failure attempt cannot resurrect bridge ----------------
+// --- Test 5: an established connection dropping rejects its in-flight requests ---
+
+const testDropRejectsInFlightRequests = async (): Promise<void> => {
+  const sockets: FakeWebSocket[] = [];
+  const responses: SendResult[] = [];
+
+  const bridge = createCdpBridge({
+    connectTimeoutMs: 60,
+    discoverWsUrl: async (): Promise<Result<string, CdpError>> => ({
+      success: true,
+      data: "ws://drop-inflight.invalid:9222",
+    }),
+    createWebSocket: (url: string): WebSocket => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    },
+  });
+
+  await bridge.start();
+  check(await waitFor(() => sockets.length === 1, "drop test socket created", 50), "drop test socket created");
+  const socket = withSocket(sockets, 0, "drop test socket exists");
+  if (!socket) {
+    await bridge.stop();
+    return;
+  }
+
+  socket.open();
+  const req: WireRequest = { type: "request", id: 41, method: "Runtime.enable", params: {} };
+  await bridge.handleRequest(req, "client-drop", (_clientId, msg) => {
+    if (msg.type === "response") {
+      responses.push(msg);
+    }
+  });
+  check(requestIdByMethod(socket, "Runtime.enable") !== null, "drop test request is in flight");
+  check(responses.length === 0, "drop test request has no response yet");
+
+  // The attempt already settled when the socket opened, so the close path must reject
+  // its callbacks itself rather than leaving them to the 10s command timeout.
+  socket.close();
+  check(
+    await waitFor(
+      () => responses.some((msg) => msg.id === 41 && msg.error?.message === "Chrome disconnected"),
+      "in-flight request rejected on drop",
+      120,
+    ),
+    "a dropped connection rejects its in-flight requests immediately",
+  );
+
+  await bridge.stop();
+};
+
+// --- Test 6: stale failure attempt cannot resurrect bridge ----------------
 
 const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
   const runStaleClosedSocketCase = async (): Promise<void> => {
@@ -467,7 +511,7 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
   await runErrorCase();
 };
 
-// --- Test 6: old-generation close should not affect newer callback ----------
+// --- Test 7: old-generation close should not affect newer callback ----------
 
 const testOldGenerationCloseDoesNotAffectNewCallbacks = async (): Promise<void> => {
   const sockets: FakeWebSocket[] = [];
@@ -561,21 +605,12 @@ const testOldGenerationCloseDoesNotAffectNewCallbacks = async (): Promise<void> 
   await bridge.stop();
 };
 
-async function main(): Promise<void> {
-  console.log("bridge connection regression tests\n");
-
-  await testConstructorFailureSettlesAttempt();
-  await testUnresolvedDiscoveryIsBounded();
-  await testHandleRequestStopsPollingAfterFailedAttempt();
-  await testStopRejectsPendingRequestCallbacks();
-  await testStaleFailureAttemptCannotResurrect();
-  await testOldGenerationCloseDoesNotAffectNewCallbacks();
-
-  console.log(`\n${passed} passed, ${failed} failed`);
-  process.exit(failed === 0 ? 0 : 1);
-}
-
-main().catch((err) => {
-  console.error("bridge regression test failed:", err);
-  process.exit(1);
+describe("cdp bridge connection lifecycle", () => {
+  test("a WebSocket constructor failure settles the attempt", testConstructorFailureSettlesAttempt);
+  test("an unresolved discovery is bounded by the connect timeout", testUnresolvedDiscoveryIsBounded);
+  test("handleRequest stops waiting once the attempt fails", testHandleRequestStopsPollingAfterFailedAttempt);
+  test("stop() rejects pending request callbacks", testStopRejectsPendingRequestCallbacks);
+  test("a dropped connection rejects its in-flight requests", testDropRejectsInFlightRequests);
+  test("a stale failed attempt cannot resurrect the bridge", testStaleFailureAttemptCannotResurrect);
+  test("an old-generation close leaves new-generation callbacks alone", testOldGenerationCloseDoesNotAffectNewCallbacks);
 });

--- a/test/manual/bridge-reconnect-regression-test.ts
+++ b/test/manual/bridge-reconnect-regression-test.ts
@@ -1,0 +1,168 @@
+/**
+ * Regression tests for `createCdpBridge` connection lifecycle races.
+ *
+ * Covers two still-open CodeRabbit findings:
+ *  1. A synchronous `new WebSocket(...)` constructor failure must settle the
+ *     current connection attempt.
+ *  2. Stale socket handlers from older attempts must not mutate shared bridge
+ *     state after a newer attempt has started.
+ *
+ * Run: npx tsx test/manual/bridge-reconnect-regression-test.ts
+ */
+
+import { EventEmitter } from "node:events";
+import { createCdpBridge } from "../../src/daemon/bridge";
+import type { Result } from "../../src/util/result";
+import type { CdpError } from "../../src/cdp/errors";
+import type WebSocket from "ws";
+
+let passed = 0;
+let failed = 0;
+const check = (cond: boolean, label: string): void => {
+  if (cond) {
+    passed++;
+    console.log(`  ✓ ${label}`);
+  } else {
+    failed++;
+    console.error(`  ✗ ${label}`);
+  }
+};
+
+class FakeWebSocket extends EventEmitter {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  public readyState = FakeWebSocket.CONNECTING;
+  public readonly sent: string[] = [];
+
+  constructor(readonly label: string) {
+    super();
+  }
+
+  send(payload: string): void {
+    this.sent.push(payload);
+  }
+
+  close(code?: number, reason?: string): void {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.emit("close", code, reason);
+  }
+
+  open(): void {
+    if (this.readyState === FakeWebSocket.OPEN) return;
+    this.readyState = FakeWebSocket.OPEN;
+    this.emit("open");
+  }
+
+  fail(error = new Error("socket error")): void {
+    this.emit("error", error);
+  }
+
+  message(data: string): void {
+    this.emit("message", data);
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+// --- Test 1: constructor failure settles the attempt ---------------------
+
+const testConstructorFailureSettlesAttempt = async (): Promise<void> => {
+  let settled = false;
+
+  const bridge = createCdpBridge({
+    discoverWsUrl: async (): Promise<Result<string, CdpError>> => ({
+      success: true,
+      data: "ws://never-used.invalid:9",
+    }),
+    createWebSocket: () => {
+      throw new Error("simulated constructor throw");
+    },
+    connectTimeoutMs: 5,
+    onAttemptSettled: () => {
+      settled = true;
+    },
+  });
+
+  bridge.start();
+  await sleep(30);
+  check(settled, "constructor failure path calls settlement callback");
+};
+
+// --- Test 2: stale handlers do not win over newer attempts ----------------
+
+const testStaleAttemptHandlersAreIgnored = async (): Promise<void> => {
+  const sockets: FakeWebSocket[] = [];
+  const urls = ["ws://attempt-1.invalid:9222", "ws://attempt-2.invalid:9222"];
+
+  const bridge = createCdpBridge({
+    discoverWsUrl: async (): Promise<Result<string, CdpError>> => {
+      const next = urls.shift();
+      if (!next) return { success: false, error: { kind: "discovery_failed", message: "no more urls" } };
+      return { success: true, data: next };
+    },
+    createWebSocket: (url: string): WebSocket => {
+      const sock = new FakeWebSocket(url);
+      sockets.push(sock);
+      return sock as unknown as WebSocket;
+    },
+    connectTimeoutMs: 30,
+  });
+
+  let closeCallbacks = 0;
+  bridge.onClose(() => {
+    closeCallbacks += 1;
+  });
+
+  await bridge.start();
+  await sleep(5);
+
+  // Stop while attempt #1 is still in CONNECTING state. This leaves the first
+  // socket alive but should not cancel its in-flight close timer.
+  await bridge.stop();
+
+  // Restart to start attempt #2.
+  await bridge.start();
+  await sleep(5);
+
+  check(sockets.length >= 2, "bridge created two connection attempts");
+  const first = sockets[0];
+  const second = sockets[1];
+
+  // Allow the fresh attempt to win.
+  second.open();
+  await sleep(5);
+  check(bridge.isAlive(), "second socket connected and keeps bridge alive");
+
+  // Let attempt #1's timeout-driven close fire after attempt #2 is active. If
+  // stale handlers are not gated by attempt identity, this closes the bridge.
+  await sleep(45);
+  check(bridge.isAlive(), "stale close event from attempt #1 does not clear active connection");
+  check(closeCallbacks === 0, "stale close handler does not invoke onClose callbacks");
+
+  // The stale socket should not receive any ownership influence; opening it after a
+  // newer attempt is active should be ignored.
+  first.open();
+  await sleep(5);
+  check(bridge.isAlive(), "stale open event does not replace the active WebSocket");
+
+  await bridge.stop();
+};
+
+async function main(): Promise<void> {
+  console.log("bridge connection regression tests\n");
+
+  await testConstructorFailureSettlesAttempt();
+  await testStaleAttemptHandlersAreIgnored();
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  console.error("bridge regression test failed:", err);
+  process.exit(1);
+});

--- a/test/manual/bridge-reconnect-regression-test.ts
+++ b/test/manual/bridge-reconnect-regression-test.ts
@@ -37,7 +37,7 @@ const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout
 
 const waitFor = async (
   predicate: () => boolean,
-  label: string,
+  _label: string,
   timeoutMs = 120,
   intervalMs = 2,
 ): Promise<boolean> => {
@@ -46,7 +46,6 @@ const waitFor = async (
     if (predicate()) return true;
     await sleep(intervalMs);
   }
-  check(false, `timed out: ${label}`);
   return false;
 };
 
@@ -164,7 +163,7 @@ const testConstructorFailureSettlesAttempt = async (): Promise<void> => {
   });
 
   await bridge.start();
-  await waitFor(() => settled, "constructor failure path calls settlement callback", 50);
+  check(await waitFor(() => settled, "constructor failure path calls settlement callback", 50), "constructor failure path calls settlement callback");
 };
 
 // --- Test 2: bounded discovery is required for unresolved discoverWsUrl ----
@@ -274,6 +273,7 @@ const testStopRejectsPendingRequestCallbacks = async (): Promise<void> => {
 
   await bridge.start();
   const initial = await waitFor(() => sockets.length === 1, "socket created for stop test", 50);
+  check(initial, "socket created for stop test");
   if (!initial) {
     await bridge.stop();
     return;
@@ -310,7 +310,7 @@ const testStopRejectsPendingRequestCallbacks = async (): Promise<void> => {
 // --- Test 5: stale failure attempt cannot resurrect bridge ----------------
 
 const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
-  const runTimeoutCase = async (): Promise<void> => {
+  const runStaleClosedSocketCase = async (): Promise<void> => {
     const sockets: FakeWebSocket[] = [];
     const responses: SendResult[] = [];
     const urls = ["ws://timedout-attempt.invalid:9222", "ws://retry-attempt.invalid:9222"];
@@ -330,8 +330,8 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
     });
 
     await bridge.start();
-    check(await waitFor(() => sockets.length >= 1, "timed out attempt socket is created", 50), "timeout test creates first socket");
-    const first = withSocket(sockets, 0, "timed-out first socket exists");
+    check(await waitFor(() => sockets.length >= 1, "stale closed socket attempt creates first socket", 50), "stale closed socket attempt creates first socket");
+    const first = withSocket(sockets, 0, "first stale socket exists");
     if (!first) {
       await bridge.stop();
       return;
@@ -339,11 +339,11 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
 
     first.open();
     first.close();
-    check(await waitFor(() => settled >= 1, "timed-out attempt settles", 80), "timed-out attempt settles");
-    check(!bridge.isAlive(), "stale timed-out open does not resurrect bridge");
+    check(await waitFor(() => settled >= 1, "stale closed socket attempt settles", 80), "stale closed socket attempt settles");
+    check(!bridge.isAlive(), "stale closed socket does not resurrect bridge");
 
     await bridge.start();
-    check(await waitFor(() => sockets.length >= 2, "retry socket is created", 80), "retry socket is created");
+    check(await waitFor(() => sockets.length >= 2, "retry socket is created after stale close", 80), "retry socket is created after stale close");
     const second = withSocket(sockets, 1, "second socket exists after retry");
     if (!second) {
       await bridge.stop();
@@ -351,7 +351,7 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
     }
 
     second.open();
-    check(await waitFor(() => bridge.isAlive(), "bridge reconnects after timeout", 80), "bridge reconnects after timeout");
+    check(await waitFor(() => bridge.isAlive(), "bridge reconnects after stale close", 80), "bridge reconnects after stale close");
 
     await bridge.handleRequest(
       { type: "request", id: 10, method: "Runtime.enable", params: {} },
@@ -371,7 +371,7 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
     }
 
     first.message(JSON.stringify({ id: secondChromeId, result: { late: true } }));
-    check(!responses.some((msg) => msg.id === 10), "timed-out stale socket cannot resolve live callback");
+    check(!responses.some((msg) => msg.id === 10), "stale closed socket cannot resolve live callback");
 
     second.message(JSON.stringify({ id: secondChromeId, result: { ok: true } }));
     check(
@@ -463,7 +463,7 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
     await bridge.stop();
   };
 
-  await runTimeoutCase();
+  await runStaleClosedSocketCase();
   await runErrorCase();
 };
 

--- a/test/manual/bridge-reconnect-regression-test.ts
+++ b/test/manual/bridge-reconnect-regression-test.ts
@@ -1,20 +1,27 @@
 /**
  * Regression tests for `createCdpBridge` connection lifecycle races.
  *
- * Covers two still-open CodeRabbit findings:
- *  1. A synchronous `new WebSocket(...)` constructor failure must settle the
- *     current connection attempt.
- *  2. Stale socket handlers from older attempts must not mutate shared bridge
- *     state after a newer attempt has started.
+ * Covers remaining lifecycle regressions after PR #18:
+ *  1. timed-out / erroring sockets must not be able to resurrect or mutate bridge
+ *     state via delayed open/message events.
+ *  2. callbacks from an old generation must be rejected/cleaned when that generation
+ *     closes after a newer attempt has started.
  *
  * Run: npx tsx test/manual/bridge-reconnect-regression-test.ts
  */
 
 import { EventEmitter } from "node:events";
-import { createCdpBridge } from "../../src/daemon/bridge";
-import type { Result } from "../../src/util/result";
+import type { WireRequest, WireResponse } from "../../src/daemon/protocol";
 import type { CdpError } from "../../src/cdp/errors";
+import type { Result } from "../../src/util/result";
+import { createCdpBridge } from "../../src/daemon/bridge";
 import type WebSocket from "ws";
+
+type ParsedSend = { id?: number; method?: string };
+
+type Discover = () => Promise<Result<string, CdpError>>;
+
+type SendResult = WireResponse;
 
 let passed = 0;
 let failed = 0;
@@ -28,6 +35,18 @@ const check = (cond: boolean, label: string): void => {
   }
 };
 
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+const waitFor = async (predicate: () => boolean, label: string, timeoutMs = 200): Promise<boolean> => {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return true;
+    await sleep(2);
+  }
+  check(false, `timed out: ${label}`);
+  return false;
+};
+
 class FakeWebSocket extends EventEmitter {
   static CONNECTING = 0;
   static OPEN = 1;
@@ -36,9 +55,14 @@ class FakeWebSocket extends EventEmitter {
 
   public readyState = FakeWebSocket.CONNECTING;
   public readonly sent: string[] = [];
+  private closeDelayMs = 0;
 
   constructor(readonly label: string) {
     super();
+  }
+
+  setCloseDelay(ms: number): void {
+    this.closeDelayMs = ms;
   }
 
   send(payload: string): void {
@@ -48,7 +72,12 @@ class FakeWebSocket extends EventEmitter {
   close(code?: number, reason?: string): void {
     if (this.readyState === FakeWebSocket.CLOSED) return;
     this.readyState = FakeWebSocket.CLOSED;
-    this.emit("close", code, reason);
+    const emitClose = () => this.emit("close", code, reason);
+    if (this.closeDelayMs > 0) {
+      setTimeout(emitClose, this.closeDelayMs);
+    } else {
+      emitClose();
+    }
   }
 
   open(): void {
@@ -66,7 +95,35 @@ class FakeWebSocket extends EventEmitter {
   }
 }
 
-const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+const makeDiscover = (urls: string[]): Discover => {
+  return async () => {
+    const next = urls.shift();
+    if (!next) {
+      return {
+        success: false,
+        error: {
+          kind: "discovery_failed",
+          message: "no more URLs",
+        },
+      };
+    }
+    return { success: true, data: next };
+  };
+};
+
+const requestIdByMethod = (socket: FakeWebSocket, method: string): number | null => {
+  for (const payload of [...socket.sent].reverse()) {
+    try {
+      const parsed = JSON.parse(payload) as ParsedSend;
+      if (parsed.method === method && typeof parsed.id === "number") {
+        return parsed.id;
+      }
+    } catch {
+      continue;
+    }
+  }
+  return null;
+};
 
 // --- Test 1: constructor failure settles the attempt ---------------------
 
@@ -88,66 +145,221 @@ const testConstructorFailureSettlesAttempt = async (): Promise<void> => {
   });
 
   bridge.start();
-  await sleep(30);
+  await sleep(20);
   check(settled, "constructor failure path calls settlement callback");
 };
 
-// --- Test 2: stale handlers do not win over newer attempts ----------------
+// --- Test 2: stale failure attempt cannot resurrect bridge ----------------
 
-const testStaleAttemptHandlersAreIgnored = async (): Promise<void> => {
+const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
+  const runTimeoutCase = async (): Promise<void> => {
+    const sockets: FakeWebSocket[] = [];
+    const responses: SendResult[] = [];
+    const urls = ["ws://timedout-attempt.invalid:9222", "ws://retry-attempt.invalid:9222"];
+    let settled = 0;
+
+    const bridge = createCdpBridge({
+      discoverWsUrl: makeDiscover(urls),
+      createWebSocket: (url: string): WebSocket => {
+        const sock = new FakeWebSocket(url);
+        sockets.push(sock);
+        return sock as unknown as WebSocket;
+      },
+      connectTimeoutMs: 15,
+      onAttemptSettled: () => {
+        settled += 1;
+      },
+    });
+
+    bridge.start();
+    await waitFor(() => sockets.length === 1, "timed out attempt socket is created");
+
+    await waitFor(() => settled >= 1, "timed-out attempt settles");
+    const first = sockets[0];
+
+    first.open();
+    await sleep(5);
+    check(!bridge.isAlive(), "stale open from timed-out socket does not resurrect bridge");
+
+    await bridge.start();
+    await waitFor(() => sockets.length >= 2, "retry socket is created");
+    const second = sockets[1];
+    second.open();
+    await waitFor(() => bridge.isAlive(), "bridge reconnects after timeout");
+
+    await bridge.handleRequest(
+      { type: "request", id: 10, method: "Runtime.enable", params: {} },
+      "client-a",
+      (_clientId, msg) => {
+        if (msg.type === "response") {
+          responses.push(msg);
+        }
+      },
+    );
+
+    const secondChromeId = requestIdByMethod(second, "Runtime.enable");
+    check(secondChromeId !== null, "second attempt sent the request");
+    if (secondChromeId === null) return;
+
+    first.open();
+    first.message(JSON.stringify({ id: secondChromeId, result: { late: true } }));
+    await sleep(5);
+    check(responses.length === 0, "timed-out stale socket cannot resolve live callback");
+
+    second.message(JSON.stringify({ id: secondChromeId, result: { ok: true } }));
+    await waitFor(() => responses.length === 1, "second attempt callback is resolved");
+    check(responses[0]?.id === 10, "current callback resolves only from active socket");
+
+    await bridge.stop();
+  };
+
+  const runErrorCase = async (): Promise<void> => {
+    const sockets: FakeWebSocket[] = [];
+    const responses: SendResult[] = [];
+    const urls = ["ws://errored-attempt.invalid:9222", "ws://retry-after-error.invalid:9222"];
+
+    const bridge = createCdpBridge({
+      discoverWsUrl: makeDiscover(urls),
+      createWebSocket: (url: string): WebSocket => {
+        const sock = new FakeWebSocket(url);
+        sockets.push(sock);
+        return sock as unknown as WebSocket;
+      },
+      connectTimeoutMs: 20,
+    });
+
+    await bridge.start();
+    await waitFor(() => sockets.length === 1, "initial attempt socket is created");
+    const first = sockets[0];
+    first.open();
+    first.setCloseDelay(15);
+
+    await bridge.handleRequest(
+      { type: "request", id: 11, method: "Runtime.enable", params: {} },
+      "client-b",
+      (_clientId, msg) => {
+        if (msg.type === "response") {
+          responses.push(msg);
+        }
+      },
+    );
+
+    first.fail(new Error("forced failure"));
+    await bridge.start();
+    await waitFor(() => sockets.length >= 2, "retry socket is created after error");
+
+    const second = sockets[1];
+    second.open();
+    await waitFor(() => bridge.isAlive(), "bridge reconnects after error");
+
+    await bridge.handleRequest(
+      { type: "request", id: 12, method: "Runtime.disable", params: {} },
+      "client-b",
+      (_clientId, msg) => {
+        if (msg.type === "response") {
+          responses.push(msg);
+        }
+      },
+    );
+
+    const secondChromeId = requestIdByMethod(second, "Runtime.disable");
+    check(secondChromeId !== null, "second attempt sent the request");
+    if (secondChromeId === null) return;
+
+    first.open();
+    first.message(JSON.stringify({ id: secondChromeId, result: { late: true } }));
+    await sleep(5);
+    check(!responses.some((msg) => msg.id === 12), "stale message from errored socket does not resolve current callback");
+
+    second.message(JSON.stringify({ id: secondChromeId, result: { ok: true } }));
+    await waitFor(() => responses.some((msg) => msg.id === 12), "current callback resolves after retry response");
+    check(
+      responses.some((msg) => msg.id === 12 && (typeof msg.result === "object" || typeof msg.result === "string" || msg.result === null)),
+      "current callback resolves after stale-socket error sequence",
+    );
+
+    await bridge.stop();
+  };
+
+  await runTimeoutCase();
+  await runErrorCase();
+  check(true, "timed-out and errored sockets do not resurrect or mutate bridge");
+};
+
+// --- Test 3: old-generation close only affects old callbacks ------------
+
+const testOldGenerationCloseDoesNotAffectNewCallbacks = async (): Promise<void> => {
   const sockets: FakeWebSocket[] = [];
-  const urls = ["ws://attempt-1.invalid:9222", "ws://attempt-2.invalid:9222"];
+  const responses: SendResult[] = [];
+  const urls = ["ws://old-gen.invalid:9222", "ws://new-gen.invalid:9222"];
 
   const bridge = createCdpBridge({
-    discoverWsUrl: async (): Promise<Result<string, CdpError>> => {
-      const next = urls.shift();
-      if (!next) return { success: false, error: { kind: "discovery_failed", message: "no more urls" } };
-      return { success: true, data: next };
-    },
+    discoverWsUrl: makeDiscover(urls),
     createWebSocket: (url: string): WebSocket => {
       const sock = new FakeWebSocket(url);
       sockets.push(sock);
       return sock as unknown as WebSocket;
     },
-    connectTimeoutMs: 30,
-  });
-
-  let closeCallbacks = 0;
-  bridge.onClose(() => {
-    closeCallbacks += 1;
+    connectTimeoutMs: 50,
   });
 
   await bridge.start();
-  await sleep(5);
-
-  // Stop while attempt #1 is still in CONNECTING state. This leaves the first
-  // socket alive but should not cancel its in-flight close timer.
-  await bridge.stop();
-
-  // Restart to start attempt #2.
-  await bridge.start();
-  await sleep(5);
-
-  check(sockets.length >= 2, "bridge created two connection attempts");
+  await waitFor(() => sockets.length === 1, "old-generation socket is created");
   const first = sockets[0];
-  const second = sockets[1];
-
-  // Allow the fresh attempt to win.
-  second.open();
-  await sleep(5);
-  check(bridge.isAlive(), "second socket connected and keeps bridge alive");
-
-  // Let attempt #1's timeout-driven close fire after attempt #2 is active. If
-  // stale handlers are not gated by attempt identity, this closes the bridge.
-  await sleep(45);
-  check(bridge.isAlive(), "stale close event from attempt #1 does not clear active connection");
-  check(closeCallbacks === 0, "stale close handler does not invoke onClose callbacks");
-
-  // The stale socket should not receive any ownership influence; opening it after a
-  // newer attempt is active should be ignored.
   first.open();
-  await sleep(5);
-  check(bridge.isAlive(), "stale open event does not replace the active WebSocket");
+
+  first.setCloseDelay(25);
+
+  const oldRequest: WireRequest = { type: "request", id: 31, method: "Target.getTargets", params: {} };
+  await bridge.handleRequest(oldRequest, "client-c", (_clientId, msg) => {
+    if (msg.type === "response") {
+      responses.push(msg);
+    }
+  });
+  const oldDaemonId = requestIdByMethod(first, "Target.getTargets");
+  check(oldDaemonId !== null, "old-generation request is in-flight");
+
+  first.close();
+  await bridge.start();
+  await waitFor(() => sockets.length === 2, "new generation socket is created");
+
+  const second = sockets[1];
+  second.open();
+  await waitFor(() => bridge.isAlive(), "bridge stays alive on new generation");
+
+  const newRequest: WireRequest = { type: "request", id: 32, method: "Runtime.getProperties", params: {} };
+  await bridge.handleRequest(newRequest, "client-c", (_clientId, msg) => {
+    if (msg.type === "response") {
+      responses.push(msg);
+    }
+  });
+
+  const newDaemonId = requestIdByMethod(second, "Runtime.getProperties");
+  check(newDaemonId !== null, "new-generation request is sent");
+  if (newDaemonId === null) return;
+
+  check(
+    !responses.some((msg) => msg.id === 31),
+    "old generation callback is not resolved before delayed close",
+  );
+
+  second.message(JSON.stringify({ id: newDaemonId, result: { ok: true } }));
+  await waitFor(() => responses.some((msg) => msg.id === 32), "new-generation callback resolves");
+
+  await waitFor(
+    () => responses.some((msg) => msg.id === 31 && msg.error?.message === "Chrome disconnected"),
+    "old-generation close rejects old callbacks",
+    80,
+  );
+
+  check(
+    responses.some((msg) => msg.id === 31 && msg.error?.message === "Chrome disconnected"),
+    "old-generation callback receives Chrome-disconnected error",
+  );
+  check(
+    !responses.some((msg) => msg.id === 32 && typeof msg.error !== "undefined"),
+    "new-generation callback is unaffected by old-generation close",
+  );
 
   await bridge.stop();
 };
@@ -156,7 +368,8 @@ async function main(): Promise<void> {
   console.log("bridge connection regression tests\n");
 
   await testConstructorFailureSettlesAttempt();
-  await testStaleAttemptHandlersAreIgnored();
+  await testStaleFailureAttemptCannotResurrect();
+  await testOldGenerationCloseDoesNotAffectNewCallbacks();
 
   console.log(`\n${passed} passed, ${failed} failed`);
   process.exit(failed === 0 ? 0 : 1);

--- a/test/manual/bridge-reconnect-regression-test.ts
+++ b/test/manual/bridge-reconnect-regression-test.ts
@@ -2,10 +2,10 @@
  * Regression tests for `createCdpBridge` connection lifecycle races.
  *
  * Covers remaining lifecycle regressions after PR #18:
- *  1. timed-out / erroring sockets must not be able to resurrect or mutate bridge
- *     state via delayed open/message events.
- *  2. callbacks from an old generation must be rejected/cleaned when that generation
- *     closes after a newer attempt has started.
+ *  1. discovery must be bounded by `connectTimeoutMs`
+ *  2. handleRequest should stop waiting as soon as the active attempt settles
+ *  3. stop() must resolve pending callbacks before clearing state
+ *  4. constructor and stale-generation cleanup still must reject old callbacks
  *
  * Run: npx tsx test/manual/bridge-reconnect-regression-test.ts
  */
@@ -18,9 +18,7 @@ import { createCdpBridge } from "../../src/daemon/bridge";
 import type WebSocket from "ws";
 
 type ParsedSend = { id?: number; method?: string };
-
 type Discover = () => Promise<Result<string, CdpError>>;
-
 type SendResult = WireResponse;
 
 let passed = 0;
@@ -37,11 +35,16 @@ const check = (cond: boolean, label: string): void => {
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
-const waitFor = async (predicate: () => boolean, label: string, timeoutMs = 200): Promise<boolean> => {
+const waitFor = async (
+  predicate: () => boolean,
+  label: string,
+  timeoutMs = 120,
+  intervalMs = 2,
+): Promise<boolean> => {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     if (predicate()) return true;
-    await sleep(2);
+    await sleep(intervalMs);
   }
   check(false, `timed out: ${label}`);
   return false;
@@ -55,14 +58,11 @@ class FakeWebSocket extends EventEmitter {
 
   public readyState = FakeWebSocket.CONNECTING;
   public readonly sent: string[] = [];
-  private closeDelayMs = 0;
+  private readonly closeDelayMs: number;
 
-  constructor(readonly label: string) {
+  constructor(readonly label: string, options: { closeDelayMs?: number } = {}) {
     super();
-  }
-
-  setCloseDelay(ms: number): void {
-    this.closeDelayMs = ms;
+    this.closeDelayMs = options.closeDelayMs ?? 0;
   }
 
   send(payload: string): void {
@@ -71,13 +71,20 @@ class FakeWebSocket extends EventEmitter {
 
   close(code?: number, reason?: string): void {
     if (this.readyState === FakeWebSocket.CLOSED) return;
-    this.readyState = FakeWebSocket.CLOSED;
-    const emitClose = () => this.emit("close", code, reason);
+
+    const closeNow = (): void => {
+      if (this.readyState === FakeWebSocket.CLOSED) return;
+      this.readyState = FakeWebSocket.CLOSED;
+      this.emit("close", code, reason);
+    };
+
     if (this.closeDelayMs > 0) {
-      setTimeout(emitClose, this.closeDelayMs);
-    } else {
-      emitClose();
+      this.readyState = FakeWebSocket.CLOSING;
+      setTimeout(closeNow, this.closeDelayMs);
+      return;
     }
+
+    closeNow();
   }
 
   open(): void {
@@ -125,11 +132,23 @@ const requestIdByMethod = (socket: FakeWebSocket, method: string): number | null
   return null;
 };
 
+const withSocket = (
+  sockets: FakeWebSocket[],
+  index: number,
+  label: string,
+): FakeWebSocket | null => {
+  const socket = sockets[index] ?? null;
+  if (!socket) {
+    check(false, label);
+    return null;
+  }
+  return socket;
+};
+
 // --- Test 1: constructor failure settles the attempt ---------------------
 
 const testConstructorFailureSettlesAttempt = async (): Promise<void> => {
   let settled = false;
-
   const bridge = createCdpBridge({
     discoverWsUrl: async (): Promise<Result<string, CdpError>> => ({
       success: true,
@@ -144,12 +163,151 @@ const testConstructorFailureSettlesAttempt = async (): Promise<void> => {
     },
   });
 
-  bridge.start();
-  await sleep(20);
-  check(settled, "constructor failure path calls settlement callback");
+  await bridge.start();
+  await waitFor(() => settled, "constructor failure path calls settlement callback", 50);
 };
 
-// --- Test 2: stale failure attempt cannot resurrect bridge ----------------
+// --- Test 2: bounded discovery is required for unresolved discoverWsUrl ----
+
+const testUnresolvedDiscoveryIsBounded = async (): Promise<void> => {
+  let settled = 0;
+  let discoverCalls = 0;
+  const sockets: FakeWebSocket[] = [];
+  const bridge = createCdpBridge({
+    discoverWsUrl: async () => {
+      discoverCalls += 1;
+      if (discoverCalls === 1) {
+        return new Promise(() => undefined);
+      }
+      return { success: true, data: "ws://retry-attempt.invalid:9222" };
+    },
+    createWebSocket: (url: string): WebSocket => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    },
+    connectTimeoutMs: 25,
+    onAttemptSettled: () => {
+      settled += 1;
+    },
+  });
+
+  await bridge.start();
+  check(await waitFor(() => settled === 1, "unresolved discovery settles by timeout", 100), "unresolved discovery is bounded by timeout");
+  check(sockets.length === 0, "timed-out discovery attempt does not create a socket");
+  check(discoverCalls === 1, "only one discover call happened before timeout");
+
+  await bridge.start();
+  check(
+    await waitFor(() => discoverCalls >= 2 && sockets.length > 0, "retry discovery creates a fresh socket after timeout", 150),
+    "retry discovery runs after bounded first attempt",
+  );
+  const retrySocket = withSocket(sockets, 0, "retry socket exists after bounded discovery timeout");
+  if (!retrySocket) {
+    await bridge.stop();
+    return;
+  }
+
+  retrySocket.open();
+  check(await waitFor(() => bridge.isAlive(), "bridge reconnects after bounded timeout"), "bridge recovers after bounded discovery timeout");
+  await bridge.stop();
+};
+
+// --- Test 3: failed attempt should short-circuit handleRequest wait -------
+
+const testHandleRequestStopsPollingAfterFailedAttempt = async (): Promise<void> => {
+  const responses: SendResult[] = [];
+  const sockets: FakeWebSocket[] = [];
+  const bridge = createCdpBridge({
+    discoverWsUrl: async (): Promise<Result<string, CdpError>> => ({
+      success: true,
+      data: "ws://fast-fail.invalid:9222",
+    }),
+    createWebSocket: (url: string): WebSocket => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      setTimeout(() => socket.fail(new Error("forced connect failure")), 0);
+      return socket as unknown as WebSocket;
+    },
+    connectTimeoutMs: 30,
+  });
+
+  await bridge.start();
+  check(await waitFor(() => sockets.length === 1, "connect attempt creates socket", 50), "handleRequest fast-fail path creates a socket");
+
+  const start = Date.now();
+  await bridge.handleRequest(
+    { type: "request", id: 20, method: "Runtime.enable", params: {} },
+    "client-fast",
+    (_clientId, msg) => {
+      if (msg.type === "response") {
+        responses.push(msg);
+      }
+    },
+  );
+  const elapsed = Date.now() - start;
+
+  check(elapsed < 200, "handleRequest returns quickly after failed attempt settlement");
+  check(
+    responses.some((msg) => msg.id === 20 && msg.error?.message === "Chrome not connected"),
+    "handleRequest fails fast with Chrome not connected",
+  );
+  await bridge.stop();
+};
+
+// --- Test 4: stop() must settle pending callbacks -----------------------
+
+const testStopRejectsPendingRequestCallbacks = async (): Promise<void> => {
+  const responses: SendResult[] = [];
+  const sockets: FakeWebSocket[] = [];
+  const bridge = createCdpBridge({
+    discoverWsUrl: async (): Promise<Result<string, CdpError>> => ({
+      success: true,
+      data: "ws://stop-callback.invalid:9222",
+    }),
+    createWebSocket: (url: string): WebSocket => {
+      const socket = new FakeWebSocket(url);
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
+    },
+  });
+
+  await bridge.start();
+  const initial = await waitFor(() => sockets.length === 1, "socket created for stop test", 50);
+  if (!initial) {
+    await bridge.stop();
+    return;
+  }
+
+  const socket = sockets[0];
+  if (!socket) {
+    await bridge.stop();
+    return;
+  }
+
+  socket.open();
+  const req: WireRequest = { type: "request", id: 40, method: "Runtime.enable", params: {} };
+  await bridge.handleRequest(req, "client-stop", (_clientId, msg) => {
+    if (msg.type === "response") {
+      responses.push(msg);
+    }
+  });
+
+  const sentDaemonId = requestIdByMethod(socket, "Runtime.enable");
+  check(sentDaemonId !== null, "stop test request is sent");
+
+  await bridge.stop();
+  check(
+    await waitFor(
+      () => responses.some((msg) => msg.id === 40 && msg.error?.message === "Chrome disconnected"),
+      "stop settles pending callback with Chrome disconnected",
+      80,
+    ),
+    "stop sends Chrome-disconnected response for pending callback",
+  );
+};
+
+// --- Test 5: stale failure attempt cannot resurrect bridge ----------------
 
 const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
   const runTimeoutCase = async (): Promise<void> => {
@@ -161,9 +319,9 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
     const bridge = createCdpBridge({
       discoverWsUrl: makeDiscover(urls),
       createWebSocket: (url: string): WebSocket => {
-        const sock = new FakeWebSocket(url);
-        sockets.push(sock);
-        return sock as unknown as WebSocket;
+        const socket = new FakeWebSocket(url);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
       },
       connectTimeoutMs: 15,
       onAttemptSettled: () => {
@@ -171,21 +329,29 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
       },
     });
 
-    bridge.start();
-    await waitFor(() => sockets.length === 1, "timed out attempt socket is created");
-
-    await waitFor(() => settled >= 1, "timed-out attempt settles");
-    const first = sockets[0];
+    await bridge.start();
+    check(await waitFor(() => sockets.length >= 1, "timed out attempt socket is created", 50), "timeout test creates first socket");
+    const first = withSocket(sockets, 0, "timed-out first socket exists");
+    if (!first) {
+      await bridge.stop();
+      return;
+    }
 
     first.open();
-    await sleep(5);
-    check(!bridge.isAlive(), "stale open from timed-out socket does not resurrect bridge");
+    first.close();
+    check(await waitFor(() => settled >= 1, "timed-out attempt settles", 80), "timed-out attempt settles");
+    check(!bridge.isAlive(), "stale timed-out open does not resurrect bridge");
 
     await bridge.start();
-    await waitFor(() => sockets.length >= 2, "retry socket is created");
-    const second = sockets[1];
+    check(await waitFor(() => sockets.length >= 2, "retry socket is created", 80), "retry socket is created");
+    const second = withSocket(sockets, 1, "second socket exists after retry");
+    if (!second) {
+      await bridge.stop();
+      return;
+    }
+
     second.open();
-    await waitFor(() => bridge.isAlive(), "bridge reconnects after timeout");
+    check(await waitFor(() => bridge.isAlive(), "bridge reconnects after timeout", 80), "bridge reconnects after timeout");
 
     await bridge.handleRequest(
       { type: "request", id: 10, method: "Runtime.enable", params: {} },
@@ -199,16 +365,19 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
 
     const secondChromeId = requestIdByMethod(second, "Runtime.enable");
     check(secondChromeId !== null, "second attempt sent the request");
-    if (secondChromeId === null) return;
+    if (secondChromeId === null) {
+      await bridge.stop();
+      return;
+    }
 
-    first.open();
     first.message(JSON.stringify({ id: secondChromeId, result: { late: true } }));
-    await sleep(5);
-    check(responses.length === 0, "timed-out stale socket cannot resolve live callback");
+    check(!responses.some((msg) => msg.id === 10), "timed-out stale socket cannot resolve live callback");
 
     second.message(JSON.stringify({ id: secondChromeId, result: { ok: true } }));
-    await waitFor(() => responses.length === 1, "second attempt callback is resolved");
-    check(responses[0]?.id === 10, "current callback resolves only from active socket");
+    check(
+      await waitFor(() => responses.some((msg) => msg.id === 10), "second attempt callback is resolved", 60),
+      "current callback resolves from active socket",
+    );
 
     await bridge.stop();
   };
@@ -221,18 +390,22 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
     const bridge = createCdpBridge({
       discoverWsUrl: makeDiscover(urls),
       createWebSocket: (url: string): WebSocket => {
-        const sock = new FakeWebSocket(url);
-        sockets.push(sock);
-        return sock as unknown as WebSocket;
+        const socket = new FakeWebSocket(url);
+        sockets.push(socket);
+        return socket as unknown as WebSocket;
       },
       connectTimeoutMs: 20,
     });
 
     await bridge.start();
-    await waitFor(() => sockets.length === 1, "initial attempt socket is created");
-    const first = sockets[0];
+    check(await waitFor(() => sockets.length === 1, "initial attempt socket is created", 50), "error test creates first socket");
+    const first = withSocket(sockets, 0, "initial socket exists after error");
+    if (!first) {
+      await bridge.stop();
+      return;
+    }
+
     first.open();
-    first.setCloseDelay(15);
 
     await bridge.handleRequest(
       { type: "request", id: 11, method: "Runtime.enable", params: {} },
@@ -245,12 +418,21 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
     );
 
     first.fail(new Error("forced failure"));
-    await bridge.start();
-    await waitFor(() => sockets.length >= 2, "retry socket is created after error");
+    first.close();
 
-    const second = sockets[1];
+    await bridge.start();
+    check(
+      await waitFor(() => sockets.length >= 2, "retry socket is created after error", 100),
+      "retry socket is created after error",
+    );
+    const second = withSocket(sockets, 1, "retry socket exists after error");
+    if (!second) {
+      await bridge.stop();
+      return;
+    }
+
     second.open();
-    await waitFor(() => bridge.isAlive(), "bridge reconnects after error");
+    check(await waitFor(() => bridge.isAlive(), "bridge reconnects after error", 80), "bridge reconnects after error");
 
     await bridge.handleRequest(
       { type: "request", id: 12, method: "Runtime.disable", params: {} },
@@ -264,18 +446,18 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
 
     const secondChromeId = requestIdByMethod(second, "Runtime.disable");
     check(secondChromeId !== null, "second attempt sent the request");
-    if (secondChromeId === null) return;
+    if (secondChromeId === null) {
+      await bridge.stop();
+      return;
+    }
 
-    first.open();
     first.message(JSON.stringify({ id: secondChromeId, result: { late: true } }));
-    await sleep(5);
     check(!responses.some((msg) => msg.id === 12), "stale message from errored socket does not resolve current callback");
 
     second.message(JSON.stringify({ id: secondChromeId, result: { ok: true } }));
-    await waitFor(() => responses.some((msg) => msg.id === 12), "current callback resolves after retry response");
     check(
-      responses.some((msg) => msg.id === 12 && (typeof msg.result === "object" || typeof msg.result === "string" || msg.result === null)),
-      "current callback resolves after stale-socket error sequence",
+      await waitFor(() => responses.some((msg) => msg.id === 12), "current callback resolves after retry response", 80),
+      "current callback resolves after retry response",
     );
 
     await bridge.stop();
@@ -283,10 +465,9 @@ const testStaleFailureAttemptCannotResurrect = async (): Promise<void> => {
 
   await runTimeoutCase();
   await runErrorCase();
-  check(true, "timed-out and errored sockets do not resurrect or mutate bridge");
 };
 
-// --- Test 3: old-generation close only affects old callbacks ------------
+// --- Test 6: old-generation close should not affect newer callback ----------
 
 const testOldGenerationCloseDoesNotAffectNewCallbacks = async (): Promise<void> => {
   const sockets: FakeWebSocket[] = [];
@@ -296,19 +477,23 @@ const testOldGenerationCloseDoesNotAffectNewCallbacks = async (): Promise<void> 
   const bridge = createCdpBridge({
     discoverWsUrl: makeDiscover(urls),
     createWebSocket: (url: string): WebSocket => {
-      const sock = new FakeWebSocket(url);
-      sockets.push(sock);
-      return sock as unknown as WebSocket;
+      const delayCloseMs = sockets.length === 0 ? 12 : 0;
+      const socket = new FakeWebSocket(url, { closeDelayMs: delayCloseMs });
+      sockets.push(socket);
+      return socket as unknown as WebSocket;
     },
     connectTimeoutMs: 50,
   });
 
   await bridge.start();
-  await waitFor(() => sockets.length === 1, "old-generation socket is created");
-  const first = sockets[0];
-  first.open();
+  check(await waitFor(() => sockets.length === 1, "old-generation socket is created", 50), "old generation socket exists");
+  const first = withSocket(sockets, 0, "old generation socket exists");
+  if (!first) {
+    await bridge.stop();
+    return;
+  }
 
-  first.setCloseDelay(25);
+  first.open();
 
   const oldRequest: WireRequest = { type: "request", id: 31, method: "Target.getTargets", params: {} };
   await bridge.handleRequest(oldRequest, "client-c", (_clientId, msg) => {
@@ -316,16 +501,26 @@ const testOldGenerationCloseDoesNotAffectNewCallbacks = async (): Promise<void> 
       responses.push(msg);
     }
   });
-  const oldDaemonId = requestIdByMethod(first, "Target.getTargets");
-  check(oldDaemonId !== null, "old-generation request is in-flight");
+
+  const oldChromeId = requestIdByMethod(first, "Target.getTargets");
+  check(oldChromeId !== null, "old-generation request is in-flight");
+  if (!oldChromeId) {
+    await bridge.stop();
+    return;
+  }
 
   first.close();
-  await bridge.start();
-  await waitFor(() => sockets.length === 2, "new generation socket is created");
 
-  const second = sockets[1];
+  await bridge.start();
+  check(await waitFor(() => sockets.length >= 2, "new generation socket is created", 80), "new generation socket exists");
+  const second = withSocket(sockets, 1, "new generation socket exists");
+  if (!second) {
+    await bridge.stop();
+    return;
+  }
+
   second.open();
-  await waitFor(() => bridge.isAlive(), "bridge stays alive on new generation");
+  check(await waitFor(() => bridge.isAlive(), "bridge stays alive on new generation", 80), "bridge stays alive on new generation");
 
   const newRequest: WireRequest = { type: "request", id: 32, method: "Runtime.getProperties", params: {} };
   await bridge.handleRequest(newRequest, "client-c", (_clientId, msg) => {
@@ -334,30 +529,32 @@ const testOldGenerationCloseDoesNotAffectNewCallbacks = async (): Promise<void> 
     }
   });
 
-  const newDaemonId = requestIdByMethod(second, "Runtime.getProperties");
-  check(newDaemonId !== null, "new-generation request is sent");
-  if (newDaemonId === null) return;
+  const newChromeId = requestIdByMethod(second, "Runtime.getProperties");
+  check(newChromeId !== null, "new-generation request is sent");
+  if (!newChromeId) {
+    await bridge.stop();
+    return;
+  }
 
+  check(!responses.some((msg) => msg.id === 31), "old generation callback is pending before close");
+
+  second.message(JSON.stringify({ id: newChromeId, result: { ok: true } }));
   check(
-    !responses.some((msg) => msg.id === 31),
-    "old generation callback is not resolved before delayed close",
-  );
-
-  second.message(JSON.stringify({ id: newDaemonId, result: { ok: true } }));
-  await waitFor(() => responses.some((msg) => msg.id === 32), "new-generation callback resolves");
-
-  await waitFor(
-    () => responses.some((msg) => msg.id === 31 && msg.error?.message === "Chrome disconnected"),
-    "old-generation close rejects old callbacks",
-    80,
+    await waitFor(() => responses.some((msg) => msg.id === 32), "new generation callback resolves", 80),
+    "new-generation callback resolves",
   );
 
   check(
-    responses.some((msg) => msg.id === 31 && msg.error?.message === "Chrome disconnected"),
+    await waitFor(
+      () => responses.some((msg) => msg.id === 31 && msg.error?.message === "Chrome disconnected"),
+      "old-generation close rejects old callbacks",
+      80,
+    ),
     "old-generation callback receives Chrome-disconnected error",
   );
+
   check(
-    !responses.some((msg) => msg.id === 32 && typeof msg.error !== "undefined"),
+    !responses.some((msg) => msg.id === 32 && msg.error !== undefined),
     "new-generation callback is unaffected by old-generation close",
   );
 
@@ -368,6 +565,9 @@ async function main(): Promise<void> {
   console.log("bridge connection regression tests\n");
 
   await testConstructorFailureSettlesAttempt();
+  await testUnresolvedDiscoveryIsBounded();
+  await testHandleRequestStopsPollingAfterFailedAttempt();
+  await testStopRejectsPendingRequestCallbacks();
   await testStaleFailureAttemptCannotResurrect();
   await testOldGenerationCloseDoesNotAffectNewCallbacks();
 


### PR DESCRIPTION
Fixes #17.

## Problem

The daemon's browser-level CDP WebSocket reconnects forever after a failed, cancelled, or disconnected connection. Chrome can display **“Allow remote debugging?”** for each attempt, so the exponential retry loop repeatedly interrupts unrelated browsing even when no new browser tool was invoked.

The long-lived Pi client deliberately keeps its daemon transport connected across sessions, so the daemon's no-client idle timeout does not reliably stop this loop.

## Fix

- Replace the background retry loop with a single, concurrency-guarded connection attempt.
- Clear the cached WebSocket URL on disconnect, reject pending requests, and remain disconnected.
- Trigger a fresh attempt only from `handleRequest()` when an explicit browser operation arrives.
- Keep the existing bounded wait so an explicit request can still wait for the user to approve Chrome's consent dialog.

This restores demand-driven recovery: Chrome restart or denied consent no longer produces unsolicited prompts, while the next `browser_*` call can reconnect without restarting the daemon.

## Verification

- Reproduced on macOS with Chrome 150 and pi-browser-harness 0.10.2: the detached daemon remained running and repeatedly reopened the consent dialog without further browser calls.
- Applied this behavior locally and confirmed the existing daemon can be stopped without further prompts; later browser work initiates a new attempt on demand.
- `npm run typecheck` passes.
- `git diff --check` passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Chrome remote-debugging consent is no longer retriggered repeatedly in the background.
  * Failed, cancelled, or disconnected Chrome connections remain disconnected until the next explicit browser request.
  * Browser requests now fail promptly with a clear “Chrome not connected” error instead of waiting indefinitely.
* **Tests**
  * Added regression coverage for connection lifecycle, timeouts, disconnects, and stale connection attempts.
* **Documentation**
  * Updated the changelog with an Unreleased entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->