### PR TITLE
fix: accept Windows script paths and start the daemon from a real install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,14 +35,16 @@ jobs:
       - name: Verify npm package
         run: npm pack --dry-run > /dev/null
 
-  # Profile discovery and pinning are the only parts of the harness whose
-  # behavior differs per operating system: user-data-dir locations, how the
-  # running browser is identified, and whether a --profile-directory launch is
-  # handed to the running browser by Chromium's ProcessSingleton. Chromium's
-  # source says all three behave the same everywhere; this job is what turns
-  # that into evidence on real macOS and Windows machines.
+  # The parts of the harness whose behavior differs per operating system:
+  # profile discovery and pinning (user-data-dir locations, how the running
+  # browser is identified, whether a --profile-directory launch is handed to the
+  # running browser by Chromium's ProcessSingleton), script-path containment
+  # (separators and case rules), and how the daemon process is spawned.
+  # Chromium's source and node:path's docs say these behave as expected
+  # everywhere; this job is what turns that into evidence on real macOS and
+  # Windows machines.
   profiles:
-    name: Profiles (${{ matrix.os }})
+    name: Platform behavior (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -70,6 +72,8 @@ jobs:
           npx tsx test/profile/list-test.ts
           npx tsx test/profile/store-test.ts
           npx tsx test/profile/browser-process-test.ts
+          npx tsx test/util/paths-test.ts
+          npx tsx test/util/daemon-socket-test.ts
         shell: bash
 
       # The runner images ship Google Chrome on all three platforms. Linux has

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ All notable changes to pi-browser-harness will be documented in this file.
 ### Fixed
 
 - **Chrome remote-debugging consent is no longer retriggered indefinitely in the background.** A cancelled, failed, or disconnected CDP connection now remains disconnected until the next explicit browser request, which makes one on-demand connection attempt instead of running an unbounded retry loop that can repeatedly interrupt normal browsing.
+- **`browser_run_script` accepts paths on Windows again.** The allowed-directory check compared against a hardcoded `/` separator, so every backslash path — including files inside `os.tmpdir()`, which the rejection message itself listed as allowed — was refused. Containment is now decided by `path.relative`, which carries each platform's own separator and case rules.
+- **The daemon starts from a production install.** `tsx` is needed to run the daemon but was declared only as a dev dependency, so `browser_setup` reported `Could not start the browser daemon` under `npm omit=dev`. It is now a runtime dependency, and the daemon is launched via the CLI entry that Node's resolver finds — a fixed `node_modules/.bin` path does not exist in a hoisted install, which is how pi lays extensions out.
 
 ## 0.11.0 — 2026-08-02
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,13 +9,13 @@
       "version": "0.11.0",
       "license": "MIT",
       "dependencies": {
+        "tsx": "^4.22.4",
         "ws": "^8.20.0"
       },
       "devDependencies": {
         "@mariozechner/pi-coding-agent": "*",
         "@mariozechner/pi-tui": "*",
         "@types/ws": "^8.18.1",
-        "tsx": "^4.22.4",
         "typebox": "*",
         "typescript": "^5.0.0"
       },
@@ -884,7 +884,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -901,7 +900,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -918,7 +916,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -935,7 +932,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -952,7 +948,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -969,7 +964,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -986,7 +980,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1003,7 +996,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,7 +1012,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1037,7 +1028,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1054,7 +1044,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1071,7 +1060,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1088,7 +1076,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1105,7 +1092,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1122,7 +1108,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1139,7 +1124,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1156,7 +1140,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1173,7 +1156,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1190,7 +1172,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1207,7 +1188,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1224,7 +1204,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,7 +1220,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1258,7 +1236,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1275,7 +1252,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1292,7 +1268,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1309,7 +1284,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3245,7 +3219,6 @@
       "version": "0.28.1",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
       "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -3485,7 +3458,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -4556,7 +4528,6 @@
       "version": "4.22.4",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
       "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@mariozechner/pi-coding-agent": "*",
     "@mariozechner/pi-tui": "*",
     "@types/ws": "^8.18.1",
-    "tsx": "^4.22.4",
     "typebox": "*",
     "typescript": "^5.0.0"
   },
@@ -70,6 +69,7 @@
     "sharp": "^0.33.0"
   },
   "dependencies": {
+    "tsx": "^4.22.4",
     "ws": "^8.20.0"
   }
 }

--- a/src/daemon/spawn.ts
+++ b/src/daemon/spawn.ts
@@ -1,12 +1,14 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { access, unlink } from "node:fs/promises";
-import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import { createConnection } from "node:net";
 import { DAEMON_SOCKET_PATH, serialize, type WireControl } from "./protocol";
 
 const moduleDir = dirname(fileURLToPath(import.meta.url));
+
+const requireFromHere = createRequire(import.meta.url);
 
 const isWindows = process.platform === "win32";
 
@@ -78,26 +80,28 @@ export const isDaemonRunning = async (timeoutMs = 2_000): Promise<boolean> => {
   });
 };
 
-export const spawnDaemon = (): ChildProcess | null => {
+// Node's own resolver, not a guessed `node_modules/.bin` path: pi installs every extension into
+// one flat, hoisted tree, so tsx lands beside the package rather than inside it and a fixed
+// `<pkg>/node_modules/.bin/tsx` lookup always misses. Resolving the CLI entry also means no shell,
+// so the Windows `.cmd` shim and its argument quoting are gone with it.
+export const daemonSpawnCommand = (): { readonly command: string; readonly args: ReadonlyArray<string> } | null => {
   const daemonScript = join(moduleDir, "index.ts");
+  try {
+    return { command: process.execPath, args: [requireFromHere.resolve("tsx/cli"), daemonScript] };
+  } catch {
+    return null;
+  }
+};
 
-  // Windows npm binaries are `.cmd` shims, which only launch through a shell — spawning one directly yields EINVAL.
-  const tsxBinBase = join(moduleDir, "..", "..", "node_modules", ".bin", "tsx");
-  const tsxBin = isWindows ? `${tsxBinBase}.cmd` : tsxBinBase;
-  const hasLocalTsx = existsSync(tsxBin);
+export const spawnDaemon = (): ChildProcess | null => {
+  const spec = daemonSpawnCommand();
+  if (!spec) return null;
 
-  const cmd = hasLocalTsx ? tsxBin : isWindows ? "npx.cmd" : "npx";
-  const args = hasLocalTsx ? [daemonScript] : ["tsx", daemonScript];
-
-  // With shell: true Node passes the command line verbatim, so a path containing spaces must be quoted or it splits into tokens.
-  const quote = (s: string): string => (isWindows ? `"${s}"` : s);
-
-  const child = spawn(quote(cmd), args.map(quote), {
+  const child = spawn(spec.command, [...spec.args], {
     detached: true,
     stdio: "ignore",
     env: { ...process.env },
-    shell: isWindows,
-    windowsVerbatimArguments: isWindows,
+    windowsHide: true,
   });
 
   child.unref();

--- a/src/domains/js.ts
+++ b/src/domains/js.ts
@@ -1,5 +1,6 @@
 import { readFile } from "node:fs/promises";
 import { resolve, isAbsolute } from "node:path";
+import { isPathWithin } from "../util/paths";
 import { tmpdir } from "node:os";
 import { createRequire } from "node:module";
 import { Type } from "typebox";
@@ -121,10 +122,7 @@ const allowedRoots = (): ReadonlyArray<string> => {
   return [tmpdir(), process.cwd(), ...(env !== undefined ? [env] : [])].map((d) => resolve(d));
 };
 
-const isPathAllowed = (p: string): boolean => {
-  const abs = resolve(p);
-  return allowedRoots().some((root) => abs === root || abs.startsWith(`${root}/`));
-};
+const isPathAllowed = (p: string): boolean => allowedRoots().some((root) => isPathWithin(root, p));
 
 const MAX_SOURCE_BYTES = 1_000_000;
 

--- a/src/util/paths.ts
+++ b/src/util/paths.ts
@@ -1,6 +1,16 @@
 import { randomUUID } from "node:crypto";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { isAbsolute, join, relative, resolve } from "node:path";
+
+// `relative` rather than a string prefix: it is separator-agnostic and carries each platform's
+// own case rules, so a Windows path is not rejected for its backslashes or its drive-letter case.
+export const isPathWithin = (root: string, target: string): boolean => {
+  const absRoot = resolve(root);
+  const absTarget = resolve(target);
+  if (absTarget === absRoot) return true;
+  const rel = relative(absRoot, absTarget);
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+};
 
 const NAMESPACE_RE = /^[a-zA-Z0-9_-]+$/;
 

--- a/test/util/daemon-socket-test.ts
+++ b/test/util/daemon-socket-test.ts
@@ -1,10 +1,11 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
 import { Type } from "typebox";
 import type { ExtensionAPI, ToolDefinition } from "@mariozechner/pi-coding-agent";
 import type { TSchema } from "typebox";
-import { daemonSocketMayExist } from "../../src/daemon/spawn";
+import { daemonSocketMayExist, daemonSpawnCommand } from "../../src/daemon/spawn";
 import { type AnyBrowserToolDefinition, registerBrowserTool } from "../../src/util/tool";
 import type { BrowserClient } from "../../src/client";
 import { ok } from "../../src/util/result";
@@ -29,6 +30,28 @@ describe("daemon socket presence check", () => {
   test("darwin uses the filesystem like linux", async () => {
     assert.equal(await daemonSocketMayExist("darwin", MISSING_SOCKET), false);
     assert.equal(await daemonSocketMayExist("darwin", thisFile), true);
+  });
+});
+
+describe("daemon spawn command", () => {
+  test("the daemon runs on this process's node, not a shell", () => {
+    const spec = daemonSpawnCommand();
+    assert.notEqual(spec, null);
+    assert.equal(spec?.command, process.execPath);
+  });
+
+  test("the resolved tsx CLI is a real file on disk", () => {
+    const cli = daemonSpawnCommand()?.args[0];
+    assert.equal(typeof cli, "string");
+    // A hoisted install puts tsx beside the package, so a `<pkg>/node_modules/.bin` guess would miss it.
+    assert.equal(existsSync(String(cli)), true, `tsx CLI not found at ${String(cli)}`);
+    assert.match(String(cli), /cli\.mjs$/);
+  });
+
+  test("the daemon entrypoint is passed to tsx", () => {
+    const script = daemonSpawnCommand()?.args[1];
+    assert.match(String(script), /[\\/]daemon[\\/]index\.ts$/);
+    assert.equal(existsSync(String(script)), true);
   });
 });
 

--- a/test/util/paths-test.ts
+++ b/test/util/paths-test.ts
@@ -1,0 +1,50 @@
+// Runs on every OS in the CI matrix on purpose: `isPathWithin` delegates to `node:path`, so
+// only a real Windows run proves the backslash and drive-letter-case cases the old check failed.
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join, resolve, sep } from "node:path";
+import { isPathWithin } from "../../src/util/paths";
+
+const root = resolve(tmpdir());
+
+describe("path containment", () => {
+  test("a directory contains itself", () => {
+    assert.equal(isPathWithin(root, root), true);
+  });
+
+  test("a direct child is contained", () => {
+    assert.equal(isPathWithin(root, join(root, "script.js")), true);
+  });
+
+  test("a nested child is contained", () => {
+    assert.equal(isPathWithin(root, join(root, "a", "b", "script.js")), true);
+  });
+
+  test("a native-separator path is contained", () => {
+    assert.equal(isPathWithin(root, `${root}${sep}script.js`), true);
+  });
+
+  test("an unnormalised path that still lands inside is contained", () => {
+    assert.equal(isPathWithin(root, join(root, "a", "..", "script.js")), true);
+  });
+
+  test("an unnormalised path that escapes the root is rejected", () => {
+    assert.equal(isPathWithin(root, join(root, "..", "..", "evil.js")), false);
+  });
+
+  test("a sibling directory sharing the root's name prefix is rejected", () => {
+    assert.equal(isPathWithin(root, `${root}-sibling${sep}script.js`), false);
+  });
+
+  test("the root's own parent is rejected", () => {
+    assert.equal(isPathWithin(root, join(root, "..")), false);
+  });
+
+  test("the roots the run-script tool allows accept a file written into them", () => {
+    for (const allowed of [tmpdir(), process.cwd()]) {
+      assert.equal(isPathWithin(allowed, join(allowed, "bh-script.mjs")), true, allowed);
+    }
+  });
+});


### PR DESCRIPTION
Fixes #22.

Two independent defects, both confirmed by reproduction rather than by reading.

## 1. `browser_run_script` rejected every path on Windows

`src/domains/js.ts` checked containment with a hardcoded forward slash:

```ts
return allowedRoots().some((root) => abs === root || abs.startsWith(`${root}/`));
```

`path.resolve()` returns backslash-separated paths on Windows, so `${root}/` never matched — including for files inside `os.tmpdir()`, which the rejection message itself listed as allowed.

Containment is now decided by `path.relative` (`isPathWithin` in `src/util/paths.ts`). It is separator-agnostic and carries each platform's own case rules. That matters: the `path.sep` patch suggested in the issue fixes the plain case but still rejects a differing drive-letter case, and Windows paths are case-insensitive.

Verified by lifting the shipped function out of `src/util/paths.ts` and running it against `path.win32` and `path.posix`:

| platform | case | result |
|---|---|---|
| win32 | the exact path from the issue | contained |
| win32 | root itself, nested child, forward-slash input | contained |
| win32 | drive/segment case differs (`c:\users\...`) | contained — the `sep` patch misses this |
| win32 | escape via `..`, sibling prefix (`Tempest`), other drive | rejected |
| posix | child, root itself | contained |
| posix | escape via `..`, sibling prefix (`/tmpfoo`), differing case | rejected |

Escape and sibling-prefix rejection match the old behaviour, so this is not a security loosening — it only stops rejecting legitimate Windows paths.

## 2. The daemon could not start from a production install

`tsx` is needed at runtime by `src/daemon/spawn.ts` but was declared only in `devDependencies`, so under `npm omit=dev` `browser_setup` returned `Could not start the browser daemon`.

**Moving `tsx` to `dependencies` alone does not fix it.** pi installs extensions into one flat, hoisted npm project (`~/.pi/agent/npm`), so tsx lands *beside* the package, not inside it. Proven on a real `--omit=dev` install of the packed tarball:

```
node_modules/tsx                                     present (hoisted to root)
node_modules/pi-browser-harness/node_modules/.bin/tsx   ABSENT  <- what the old code looked for
node_modules/.bin/tsx                                where the bin actually landed
```

The old lookup misses and falls through to `npx tsx`, which resolves against the spawning process's cwd (the user's project, not pi's install root), tries a registry install, and dies against `stdio: "ignore"`.

So the CLI entry is now located with Node's own resolver, which walks up to the hoisted copy:

```
require.resolve("tsx/cli") -> <install>/node_modules/tsx/dist/cli.mjs
```

End-to-end proof — the daemon spawned from that same `--omit=dev` install:

```
[pi-browser-daemon] Starting...
[pi-browser-daemon] IPC server listening
[pi-browser-daemon] Connected to Chrome ✓
```

Because there is no shell any more, this also deletes the Windows `.cmd` shim branch, `shell: true`, `windowsVerbatimArguments`, the manual `quote()` helper that paths with spaces needed, and the `npx` fallback. `windowsHide: true` is added so the detached child does not flash a console window — worth a look, since it is a visible behaviour change.

## Tests

Both fixes are in platform-branching code, so a Linux-only run cannot exercise either. The repo already has a three-OS matrix job built for exactly this; the new tests are registered there and run for real on `windows-latest` and `macos-latest`.

- `test/util/paths-test.ts` (new) — 9 containment cases against the running platform's `node:path`.
- `test/util/daemon-socket-test.ts` — asserts the spawn command uses `process.execPath`, that the resolved tsx CLI exists on disk, and that the daemon entrypoint is passed to it. Nothing is spawned.
- `test/manual/profile-concurrency-test.ts` already calls `spawnDaemon()` and runs in CI, so a broken spawn fails the build.

The job comment and name were updated — it now covers more than profiles.

## Verification

- `npm run check` — 314 tests, 0 fail (302 before), boundary check clean, typecheck clean.
- `npm ci --dry-run` passes; `package-lock.json` regenerated for the dependency move (the diff is only tsx's placement and the `dev: true` markers on its esbuild binaries).
- `npm pack --dry-run` — 82 files.

Windows end-to-end is not reproducible locally. The win32 path behaviour rests on the `path.win32` proofs above plus the CI matrix. @ the reporter of #22 — a confirmation on real Windows hardware would be welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows path validation for browser scripts, including normalized paths and sibling-directory checks.
  - Improved production daemon startup reliability by resolving the runtime launcher through the application’s command-line entry point.
- **Tests**
  - Added cross-platform coverage for path containment and daemon startup behavior.
- **Documentation**
  - Updated the unreleased changelog with the path validation and daemon startup fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->