### PR TITLE
release: 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to pi-browser-harness will be documented in this file.
 
-## Unreleased
+## 0.11.1 — 2026-08-12
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-browser-harness",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-browser-harness",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "MIT",
       "dependencies": {
         "tsx": "^4.22.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-browser-harness",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Browser control extension for pi — navigate, click, type, screenshot, and extract data from real Chrome via CDP",
   "keywords": [
     "pi-package",


### PR DESCRIPTION
## Problem

Repeated Chrome "Allow Remote Debugging" consent prompts were fixed by #18 (on-demand CDP reconnect) and hardened by #23, but `npm i pi-browser-harness` still installs 0.11.0 — the last published release predates both merges, so users never get the fix.

## Fix

Cut release **0.11.1** containing the three landed fixes (issue #17, PR #18, PR #23):

- Bump `package.json` / `package-lock.json` to 0.11.1.
- Promote the `Unreleased` changelog section to `## 0.11.1 — 2026-08-12` with the three Fixed bullets.

## Testing

- `node --conditions=import --import tsx --test test/daemon/bridge-connection-test.ts` — 7/7 pass
- `npm run check` (typecheck + boundaries + full suite) — 306 pass, 0 fail, 8 skipped
- `npm pack --dry-run` — `pi-browser-harness-0.11.1.tgz` (82 files)
- `git diff --check` — clean

## After merge

Please tag `v0.11.1` on main to trigger the existing publish workflow — npm latest remains 0.11.0 until the tag lands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Published version 0.11.1 dated August 12, 2026.
  * Updated the package version to 0.11.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->